### PR TITLE
Enhances access request email with app details

### DIFF
--- a/centre-api/src/centre_api/config.py
+++ b/centre-api/src/centre_api/config.py
@@ -88,6 +88,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     APP_NAME = os.getenv('APP_NAME')
     DST_EMAIL = os.getenv('DST_EMAIL')
+    EPIC_CENTRE_WEB_URL = os.getenv('EPIC_CENTRE_WEB_URL', 'http://localhost:5173')
 
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/centre-api/src/centre_api/services/applications_service.py
+++ b/centre-api/src/centre_api/services/applications_service.py
@@ -8,7 +8,7 @@ from centre_api.models import Application as ApplicationModel
 from centre_api.models import EmailQueue
 from centre_api.models.access_requests import AccessRequests as AccessRequestsModal
 from centre_api.models.db import session_scope
-from centre_api.utils.datetime_util import local_datetime, convert_utc_to_local_str, utc_datetime
+from centre_api.utils.datetime_util import convert_utc_to_local_str
 from centre_api.utils.token_info import TokenInfo
 
 

--- a/centre-api/src/centre_api/services/applications_service.py
+++ b/centre-api/src/centre_api/services/applications_service.py
@@ -8,6 +8,7 @@ from centre_api.models import Application as ApplicationModel
 from centre_api.models import EmailQueue
 from centre_api.models.access_requests import AccessRequests as AccessRequestsModal
 from centre_api.models.db import session_scope
+from centre_api.utils.datetime_util import local_datetime, convert_utc_to_local_str, utc_datetime
 from centre_api.utils.token_info import TokenInfo
 
 
@@ -74,16 +75,20 @@ class ApplicationsService:
         ]
 
     @classmethod
-    def _queue_access_request_submitted_email(cls, session):
+    def _queue_access_request_submitted_email(cls, session, app):
         """Queue access request submitted email."""
         user_details = TokenInfo.get_user_data()
+        now = datetime.datetime.utcnow()
+        requested_at = convert_utc_to_local_str(now)
         email_queue = EmailQueue(
             template_name=EmailQueueTemplate.ACCESS_REQUEST_SUBMITTED_CONFIRMATION.value,
             payload={
                 'recipients': [user_details.get('email_address')],
                 'user_name': f"{user_details.get('first_name', '')} {user_details.get('last_name', '')}".strip(),
-                'application_name': os.getenv('APP_NAME', 'EPIC.centre'),
-                'requested_at': datetime.datetime.utcnow(),
+                'application_name': app.title,
+                'application_url': app.launch_url,
+                'epic_centre_link': f"{os.getenv('EPIC_CENTRE_WEB_URL')}/request-access",
+                'requested_at': requested_at,
                 'sender': os.getenv('DST_EMAIL')
             },
         )
@@ -106,7 +111,7 @@ class ApplicationsService:
             new_request = AccessRequestsModal(app_id=app_id, user_auth_guid=user_auth_id)
             session.add(new_request)
             session.flush()
-            cls._queue_access_request_submitted_email(session)
+            cls._queue_access_request_submitted_email(session, app)
             session.commit()
 
         return new_request

--- a/centre-api/src/centre_api/utils/datetime_util.py
+++ b/centre-api/src/centre_api/utils/datetime_util.py
@@ -32,18 +32,15 @@ def utc_datetime():
     return now
 
 
-def convert_and_format_to_utc_str(date_val: datetime, dt_format='%Y-%m-%d %H:%M:%S', timezone_override=None):
-    """Convert a datetime object to UTC and format it as a string."""
-    tz_name = timezone_override or current_app.config['LEGISLATIVE_TIMEZONE']
-    tz_local = pytz.timezone(tz_name)
+def convert_utc_to_local_str(utc_dt: datetime, dt_format='%Y-%m-%d %I:%M %p %Z', timezone_override=None):
+    """
+    Convert a  UTC datetime to local timezone and format it.
+    """
+    utc_dt = pytz.utc.localize(utc_dt)
 
-    # Assume the input datetime is in the local time zone
-    date_val = tz_local.localize(date_val)
+    tz_name = timezone_override or current_app.config.get('LEGISLATIVE_TIMEZONE', 'US/Pacific')
+    local_tz = pytz.timezone(tz_name)
+    local_dt = utc_dt.astimezone(local_tz)
 
-    # Convert to UTC
-    date_val_utc = date_val.astimezone(pytz.UTC)
-
-    # Format as a string
-    utc_datetime_str = date_val_utc.strftime(dt_format)
-
-    return utc_datetime_str
+    # Step 3: Format
+    return local_dt.strftime(dt_format)

--- a/centre-api/src/centre_api/utils/datetime_util.py
+++ b/centre-api/src/centre_api/utils/datetime_util.py
@@ -33,9 +33,7 @@ def utc_datetime():
 
 
 def convert_utc_to_local_str(utc_dt: datetime, dt_format='%Y-%m-%d %I:%M %p %Z', timezone_override=None):
-    """
-    Convert a  UTC datetime to local timezone and format it.
-    """
+    """Convert a  UTC datetime to local timezone and format it."""
     utc_dt = pytz.utc.localize(utc_dt)
 
     tz_name = timezone_override or current_app.config.get('LEGISLATIVE_TIMEZONE', 'US/Pacific')


### PR DESCRIPTION
Updates the access request email to include the application name, URL, and a link to the EPIC.centre, providing users with more context and easier access to the requested application. Also includes the request submission time.

This change involves:

- Adding `EPIC_CENTRE_WEB_URL` to the configuration to allow easy access to the EPIC.centre web application.
- Modifying the email template to include the application name, application URL, a direct link to EPIC.centre, and the request submission timestamp.
- Moving datetime utils to a dedicated file.

Relates to CENTRE-task#16