### PR TITLE
CENTRE-29 Create EPIC.auth page with all users tab

### DIFF
--- a/centre-api/src/centre_api/enums/epic_app.py
+++ b/centre-api/src/centre_api/enums/epic_app.py
@@ -65,3 +65,5 @@ APP_NAME_TO_GROUP_MAP = {
     EpicAppName.EPIC_SUBMIT.value: EpicGroups.SUBMIT.value,
     EpicAppName.EPIC_TRACK.value: EpicGroups.TRACK.value,
 }
+
+GROUP_TO_APP_NAME_MAP = {v: k for k, v in APP_NAME_TO_GROUP_MAP.items()}

--- a/centre-api/src/centre_api/resources/__init__.py
+++ b/centre-api/src/centre_api/resources/__init__.py
@@ -27,6 +27,7 @@ from .apihelper import Api
 from .applications import API as APPLICATIONS_API
 from .ops import API as OPS_API
 from .user_application import API as USER_APPLICATION_API
+from .users import API as USERS_API
 
 
 __all__ = ('API_BLUEPRINT', 'OPS_BLUEPRINT')
@@ -65,3 +66,4 @@ API = Api(
 
 API.add_namespace(APPLICATIONS_API)
 API.add_namespace(USER_APPLICATION_API)
+API.add_namespace(USERS_API)

--- a/centre-api/src/centre_api/resources/users.py
+++ b/centre-api/src/centre_api/resources/users.py
@@ -1,0 +1,43 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API endpoints for managing an user resource."""
+
+from http import HTTPStatus
+
+from flask_restx import Namespace, Resource
+
+from centre_api.auth import auth
+from centre_api.resources.apihelper import Api as ApiHelper
+from centre_api.schemas.user import UserSchema
+from centre_api.services.user_service import UserService
+from centre_api.utils.util import cors_preflight
+
+
+API = Namespace('users', description='Endpoints for applications management')
+"""Custom exception messages
+"""
+
+
+@cors_preflight('GET, OPTIONS')
+@API.route('', methods=['GET', 'OPTIONS'])
+class Users(Resource):
+    """Resource for fetching users."""
+
+    @staticmethod
+    @ApiHelper.swagger_decorators(API, endpoint_description='Fetch all users')
+    @auth.require
+    def get():
+        """Fetch all users."""
+        users = UserService.get_users()
+        return UserSchema(many=True).dump(users), HTTPStatus.OK

--- a/centre-api/src/centre_api/schemas/user.py
+++ b/centre-api/src/centre_api/schemas/user.py
@@ -1,0 +1,21 @@
+"""User schema.
+
+This module defines the schema for the user entity.
+"""
+
+from marshmallow import Schema, fields, post_dump
+
+
+class UserSchema(Schema):
+    """Schema for serializing user data without exposing internal fields like 'groups'."""
+    id = fields.UUID()
+    first_name = fields.Str()
+    last_name = fields.Str()
+    email = fields.Email(attribute='email_address')
+    username = fields.Str()
+    apps = fields.List(fields.Str())
+
+    @post_dump
+    def sort_apps(self, data, **kwargs):  # pylint: disable=unused-argument
+        data["apps"] = sorted(data.get("apps", []))
+        return data

--- a/centre-api/src/centre_api/schemas/user.py
+++ b/centre-api/src/centre_api/schemas/user.py
@@ -8,6 +8,7 @@ from marshmallow import Schema, fields, post_dump
 
 class UserSchema(Schema):
     """Schema for serializing user data without exposing internal fields like 'groups'."""
+
     id = fields.UUID()
     first_name = fields.Str()
     last_name = fields.Str()
@@ -17,5 +18,6 @@ class UserSchema(Schema):
 
     @post_dump
     def sort_apps(self, data, **kwargs):  # pylint: disable=unused-argument
-        data["apps"] = sorted(data.get("apps", []))
+        """Ensure the apps list is sorted."""
+        data['apps'] = sorted(data.get('apps', []))
         return data

--- a/centre-api/src/centre_api/services/auth_api_service.py
+++ b/centre-api/src/centre_api/services/auth_api_service.py
@@ -41,3 +41,22 @@ class AuthApiService:
         except requests.RequestException as e:
             current_app.logger.error(f'Error fetching group members: {e}')
             return []
+
+    @staticmethod
+    def get_users():
+        """Get users."""
+        try:
+            headers = {
+                'Content-Type': 'application/json',
+                'Authorization': g.authorization_header,
+            }
+
+            include_groups = 'true'
+            url = f'{os.getenv("AUTH_API")}/api/users?include_groups={include_groups}'
+            timeout = current_app.config.get('CONNECT_TIMEOUT', 30)
+            response = requests.get(url, headers=headers, timeout=timeout)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            current_app.logger.error(f'Error fetching users: {e}')
+            return []

--- a/centre-api/src/centre_api/services/user_service.py
+++ b/centre-api/src/centre_api/services/user_service.py
@@ -1,0 +1,34 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""user functions."""
+from centre_api.enums.epic_app import GROUP_TO_APP_NAME_MAP
+from centre_api.services.auth_api_service import AuthApiService
+
+
+class UserService:
+    """Service for handling user-related operations."""
+
+    @classmethod
+    def get_users(cls):
+        """Retrieve users and enrich them with application access information."""
+        users = AuthApiService.get_users()
+        return [cls._enrich_user_with_apps(user) for user in users]
+
+    @staticmethod
+    def _enrich_user_with_apps(user):
+        """Enrich a single user dictionary with app names based on their groups."""
+        group_paths = [group['path'] for group in user.get('groups', [])]
+        app_names = {GROUP_TO_APP_NAME_MAP.get(path.split('/')[0]) for path in group_paths}
+        user['apps'] = sorted(filter(None, app_names))
+        return user

--- a/centre-web/package-lock.json
+++ b/centre-web/package-lock.json
@@ -20,6 +20,7 @@
         "@tanstack/router-plugin": "^1.45.7",
         "axios": "^1.7.2",
         "epic.theme": "^1.0.11",
+        "jwt-decode": "^4.0.0",
         "keycloak-js": "^25.0.1",
         "oidc-client-ts": "^3.0.1",
         "react": "^18.2.0",

--- a/centre-web/package.json
+++ b/centre-web/package.json
@@ -22,6 +22,7 @@
     "@tanstack/router-plugin": "^1.45.7",
     "axios": "^1.7.2",
     "epic.theme": "^1.0.11",
+    "jwt-decode": "^4.0.0",
     "keycloak-js": "^25.0.1",
     "oidc-client-ts": "^3.0.1",
     "react": "^18.2.0",

--- a/centre-web/src/components/AuthManagement/AllUsers/UsersTable/TableBody.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/UsersTable/TableBody.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import UsersTableRow from "./TableRow";
+import { TableBody, TableRow } from "@mui/material";
+import { CentreTableCell } from "@/components/Shared/CentreTable";
+
+interface TableBodyProps {
+  users: Array<any>;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export const UsersTableBody: React.FC<TableBodyProps> = ({
+  users,
+  isLoading,
+  isError,
+}) => {
+  if (isLoading) {
+    return (
+      <TableRow>
+        <CentreTableCell colSpan={3}>Loading...</CentreTableCell>
+      </TableRow>
+    );
+  }
+
+  if (isError) {
+    return (
+      <TableRow>
+        <CentreTableCell colSpan={3}>Error loading users</CentreTableCell>
+      </TableRow>
+    );
+  }
+
+  return (
+    <TableBody>
+      {users.map((user) => (
+        <UsersTableRow key={user.id} user={user} />
+      ))}
+    </TableBody>
+  );
+};

--- a/centre-web/src/components/AuthManagement/AllUsers/UsersTable/TableHead.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/UsersTable/TableHead.tsx
@@ -1,0 +1,26 @@
+import { CentreTableHeadCell } from "@/components/Shared/CentreTable";
+import { TableHead, TableRow } from "@mui/material";
+import { BCDesignTokens } from "epic.theme";
+
+export default function UsersTableHead() {
+  return (
+    <TableHead
+      sx={{
+        border: 0,
+        ".MuiTableCell-root": {
+          p: BCDesignTokens.layoutPaddingXsmall,
+        },
+      }}
+    >
+      <TableRow>
+        <CentreTableHeadCell sx={{ width: "15%" }}>
+          User Name
+        </CentreTableHeadCell>
+        <CentreTableHeadCell sx={{ width: "70%" }}>
+          Application
+        </CentreTableHeadCell>
+        <CentreTableHeadCell sx={{ width: "15%" }}>Action</CentreTableHeadCell>
+      </TableRow>
+    </TableHead>
+  );
+}

--- a/centre-web/src/components/AuthManagement/AllUsers/UsersTable/TableRow.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/UsersTable/TableRow.tsx
@@ -1,0 +1,19 @@
+import { CentreLink } from "@/components/Shared/CentreLink";
+import { CentreTableCell } from "@/components/Shared/CentreTable";
+import { CentreUser } from "@/models/CentreUser";
+import { TableRow } from "@mui/material";
+
+type Props = {
+  readonly user: CentreUser;
+};
+export default function UsersTableRow({ user }: Props) {
+  return (
+    <TableRow>
+      <CentreTableCell>{`${user.last_name}, ${user.first_name}`}</CentreTableCell>
+      <CentreTableCell>{user.apps.join(", ")}</CentreTableCell>
+      <CentreTableCell>
+        <CentreLink>View/Edit Access</CentreLink>
+      </CentreTableCell>
+    </TableRow>
+  );
+}

--- a/centre-web/src/components/AuthManagement/AllUsers/UsersTable/index.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/UsersTable/index.tsx
@@ -1,0 +1,52 @@
+import { Box, Table, TableContainer, TablePagination } from "@mui/material";
+import UsersTableHead from "./TableHead";
+import { useGetUsers } from "@/hooks/api/useUsers";
+import React, { useState } from "react";
+import { UsersTableBody } from "./TableBody";
+
+export const UsersTable = () => {
+  const { data: users = [], isLoading, isError } = useGetUsers();
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+
+  // Paginate users client-side
+  const paginatedUsers = users.slice(
+    page * rowsPerPage,
+    page * rowsPerPage + rowsPerPage,
+  );
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box>
+      <TableContainer>
+        <Table>
+          <UsersTableHead />
+          <UsersTableBody
+            users={paginatedUsers}
+            isLoading={isLoading}
+            isError={isError}
+          />
+        </Table>
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[5, 10, 25]}
+        component="div"
+        count={users.length}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+      />
+    </Box>
+  );
+};

--- a/centre-web/src/components/AuthManagement/AllUsers/index.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/index.tsx
@@ -1,0 +1,3 @@
+export const AllUsers = () => {
+  return <div>All Users</div>;
+};

--- a/centre-web/src/components/AuthManagement/AllUsers/index.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/index.tsx
@@ -1,5 +1,6 @@
 import { Button, Grid, Stack, TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
+import { UsersTable } from "./UsersTable";
 
 export const AllUsers = () => {
   return (
@@ -30,6 +31,9 @@ export const AllUsers = () => {
             <SearchIcon sx={{ height: "30px", width: "30px" }} />
           </Button>
         </Stack>
+      </Grid>
+      <Grid item xs={12}>
+        <UsersTable />
       </Grid>
     </Grid>
   );

--- a/centre-web/src/components/AuthManagement/AllUsers/index.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/index.tsx
@@ -1,3 +1,36 @@
+import { Button, Grid, Stack, TextField } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+
 export const AllUsers = () => {
-  return <div>All Users</div>;
+  return (
+    <Grid container spacing={2} mt={"1em"}>
+      <Grid item xs={12}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <TextField
+            variant="outlined"
+            placeholder="Search users by name"
+            InputProps={{
+              startAdornment: (
+                <SearchIcon
+                  sx={{ color: "#7B90A7", height: "30px", width: "30px" }}
+                />
+              ),
+            }}
+            sx={{
+              width: "400px",
+            }}
+          />
+          <Button
+            sx={{
+              width: "40px",
+              height: "40px",
+              minWidth: "40px",
+            }}
+          >
+            <SearchIcon sx={{ height: "30px", width: "30px" }} />
+          </Button>
+        </Stack>
+      </Grid>
+    </Grid>
+  );
 };

--- a/centre-web/src/components/AuthManagement/NewRequests/index.tsx
+++ b/centre-web/src/components/AuthManagement/NewRequests/index.tsx
@@ -1,0 +1,3 @@
+export const NewRequests = () => {
+  return <div>New Requests</div>;
+};

--- a/centre-web/src/components/DocumentSearch/index.tsx
+++ b/centre-web/src/components/DocumentSearch/index.tsx
@@ -12,7 +12,7 @@ export const DocumentSearch = ({ epicApp }: DocumentSearch) => {
     <Paper
       elevation={2}
       sx={{
-        width: "100%",
+        maxWidth: "1070px",
         boxShadow: BCDesignTokens.surfaceShadowMedium,
       }}
     >

--- a/centre-web/src/components/Shared/CentreTable/index.tsx
+++ b/centre-web/src/components/Shared/CentreTable/index.tsx
@@ -1,0 +1,50 @@
+import { TableCell, TableCellProps } from "@mui/material";
+import { BCDesignTokens } from "epic.theme";
+
+export const CentreTableHeadCell = (props: TableCellProps) => {
+  const { children, sx, ...rest } = props;
+  return (
+    <TableCell
+      sx={{
+        color: BCDesignTokens.themeGray70,
+        fontSize: BCDesignTokens.typographyFontSizeSmallBody,
+        "&:hover": {
+          color: BCDesignTokens.surfaceColorMenusHover,
+        },
+        border: "none",
+        padding: BCDesignTokens.layoutPaddingXsmall,
+        ...sx,
+      }}
+      {...rest}
+    >
+      {children}
+    </TableCell>
+  );
+};
+
+export const CentreTableCell = (props: TableCellProps) => {
+  const { children, sx, ...rest } = props;
+  return (
+    <TableCell
+      sx={{
+        borderTop: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
+        borderBottom: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
+        padding: `${BCDesignTokens.layoutPaddingSmall} !important`,
+        "&:first-of-type": {
+          borderLeft: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
+          borderTopLeftRadius: 5,
+          borderBottomLeftRadius: 5,
+        },
+        "&:last-of-type": {
+          borderRight: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
+          borderTopRightRadius: 5,
+          borderBottomRightRadius: 5,
+        },
+        ...sx,
+      }}
+      {...rest}
+    >
+      {children}
+    </TableCell>
+  );
+};

--- a/centre-web/src/components/Shared/CentreTabs/CentreTab.tsx
+++ b/centre-web/src/components/Shared/CentreTabs/CentreTab.tsx
@@ -1,0 +1,60 @@
+import { Box, Tab, TabProps, Tabs, TabsProps } from "@mui/material";
+import { BCDesignTokens } from "epic.theme";
+
+export const CentreTab = (props: TabProps) => {
+  const { children, sx, ...rest } = props;
+  return (
+    <Tab
+      disableRipple
+      sx={{
+        height: "35px",
+        minHeight: 0,
+        border: `1px solid ${BCDesignTokens.surfaceColorSecondaryButtonHover}`,
+        borderRadius: "0px",
+        borderBottom: "none",
+        fontWeight: "inherit",
+        color: BCDesignTokens.surfaceColorPrimaryButtonDefault,
+        marginRight: "8px",
+        backgroundColor: BCDesignTokens.surfaceColorBackgroundLightGray,
+        "&.Mui-selected": {
+          backgroundColor: BCDesignTokens.surfaceColorSecondaryButtonDefault,
+          color: BCDesignTokens.typographyColorPrimary,
+          border: `1px solid ${BCDesignTokens.surfaceColorSecondaryButtonHover}`,
+          borderBottom: "none",
+          fontWeight: "700",
+        },
+        ...sx,
+      }}
+      {...rest}
+    >
+      {children}
+    </Tab>
+  );
+};
+
+export const CentreTabs = (props: TabsProps) => {
+  const { children, TabIndicatorProps, ...rest } = props;
+  const { sx: TipSx, ...restTabIndicatorProps } = TabIndicatorProps ?? {};
+  return (
+    <Box
+      sx={{
+        borderBottom: 2,
+        borderColor: BCDesignTokens.themePrimaryGold,
+        "& .MuiTabs-root": {
+          height: 35,
+          minHeight: 0,
+        },
+      }}
+    >
+      <Tabs
+        TabIndicatorProps={{
+          sx: { display: "none", ...TipSx },
+          ...restTabIndicatorProps,
+        }}
+        {...rest}
+      >
+        {children}
+      </Tabs>
+    </Box>
+  );
+};

--- a/centre-web/src/components/Shared/CentreTabs/CentreTabPanel.tsx
+++ b/centre-web/src/components/Shared/CentreTabs/CentreTabPanel.tsx
@@ -1,0 +1,19 @@
+import { Box, BoxProps } from "@mui/material";
+
+type CentreTabPanelProps = BoxProps & {
+  index?: number;
+  value?: number;
+};
+export const CentreTabPanel = (props: CentreTabPanelProps) => {
+  const { children, index, value, ...rest } = props;
+
+  if (value !== index) {
+    return null;
+  }
+
+  return (
+    <Box role="tabpanel" {...rest}>
+      {children}
+    </Box>
+  );
+};

--- a/centre-web/src/components/Shared/PageGrid.tsx
+++ b/centre-web/src/components/Shared/PageGrid.tsx
@@ -1,12 +1,15 @@
 import { Box, BoxProps } from "@mui/material";
 
 export const PageContainer = ({ children, ...rest }: BoxProps) => {
+  const { sx, ...other } = rest;
   return (
     <Box
       sx={{
         padding: "36px 24px",
+        width: "100%",
+        ...sx,
       }}
-      {...rest}
+      {...other}
     >
       {children}
     </Box>

--- a/centre-web/src/components/Shared/PermissionGate/index.tsx
+++ b/centre-web/src/components/Shared/PermissionGate/index.tsx
@@ -1,0 +1,33 @@
+import { cloneElement, useMemo } from "react";
+import { getUserRolesFromToken, hasPermission } from "./utils";
+import { useAuth } from "react-oidc-context";
+
+type PermissionsGateProps = Readonly<{
+  children: React.ReactElement;
+  RenderError?: React.ComponentType;
+  errorProps?: Record<string, unknown>;
+  scopes: string[];
+}>;
+
+export default function PermissionsGate({
+  children,
+  RenderError = () => <></>,
+  scopes = [],
+  errorProps,
+}: PermissionsGateProps) {
+  const { user } = useAuth();
+
+  const permissions = useMemo(
+    () => getUserRolesFromToken(user?.access_token) || [],
+    [user?.access_token],
+  );
+
+  const permissionGranted = hasPermission({ permissions, scopes });
+
+  if (!permissionGranted && !errorProps) return <RenderError />;
+
+  if (!permissionGranted && errorProps)
+    return cloneElement(children, { ...errorProps });
+
+  return <>{children}</>;
+}

--- a/centre-web/src/components/Shared/PermissionGate/utils.ts
+++ b/centre-web/src/components/Shared/PermissionGate/utils.ts
@@ -1,0 +1,27 @@
+import { AppConfig } from "@/utils/config";
+import { jwtDecode } from "jwt-decode";
+
+export const hasPermission = ({
+  permissions,
+  scopes,
+}: {
+  permissions: string[];
+  scopes: string[];
+}) => {
+  const scopesMap = scopes.reduce(
+    (acc, scope) => {
+      acc[scope] = true;
+      return acc;
+    },
+    {} as Record<string, boolean>,
+  );
+
+  return permissions.some((permission) => scopesMap[permission]);
+};
+
+export const getUserRolesFromToken = (token?: string) => {
+  if (!token) return [];
+  const tokenData: any = jwtDecode(token);
+  const appName = AppConfig.clientId;
+  return tokenData?.resource_access?.[appName]?.roles || [];
+};

--- a/centre-web/src/components/SideNav/Routes.tsx
+++ b/centre-web/src/components/SideNav/Routes.tsx
@@ -1,8 +1,6 @@
 import { BCDesignTokens } from "epic.theme";
 import { MainListItem } from "./MainListItem";
-import PermissionsGate from "../Shared/PermissionGate";
 import { SubListItem } from "./SubListItem";
-import { EpicCentreRoles } from "@/models/Roles";
 
 export default function Routes() {
   return (
@@ -20,7 +18,6 @@ export default function Routes() {
           path: "/request-access",
         }}
       />
-      {/* <PermissionsGate scopes={[EpicCentreRoles.manage_requests]}> */}
       <SubListItem
         key={`sub-list-auth-management`}
         route={{
@@ -28,7 +25,6 @@ export default function Routes() {
           path: `/request-access/auth`,
         }}
       />
-      {/* </PermissionsGate> */}
     </>
   );
 }

--- a/centre-web/src/components/SideNav/Routes.tsx
+++ b/centre-web/src/components/SideNav/Routes.tsx
@@ -1,5 +1,8 @@
 import { BCDesignTokens } from "epic.theme";
 import { MainListItem } from "./MainListItem";
+import PermissionsGate from "../Shared/PermissionGate";
+import { SubListItem } from "./SubListItem";
+import { EpicCentreRoles } from "@/models/Roles";
 
 export default function Routes() {
   return (
@@ -16,8 +19,16 @@ export default function Routes() {
           name: "Request Access",
           path: "/request-access",
         }}
-        sx={{ mb: BCDesignTokens.layoutMarginSmall }}
       />
+      {/* <PermissionsGate scopes={[EpicCentreRoles.manage_requests]}> */}
+      <SubListItem
+        key={`sub-list-auth-management`}
+        route={{
+          name: "EPIC.auth",
+          path: `/request-access/auth`,
+        }}
+      />
+      {/* </PermissionsGate> */}
     </>
   );
 }

--- a/centre-web/src/components/SideNav/SubListItem.tsx
+++ b/centre-web/src/components/SideNav/SubListItem.tsx
@@ -1,0 +1,58 @@
+import { alpha, ListItem, ListItemButton } from "@mui/material";
+import { RouteType } from "./SideNavElements";
+import { Link, useRouterState } from "@tanstack/react-router";
+import { theme } from "@/styles/theme";
+import { BCDesignTokens } from "epic.theme";
+
+export const SubListItem = ({ route }: { route: RouteType }) => {
+  const router = useRouterState();
+  const currentPath = router.location.pathname;
+  const isActive =
+    currentPath === route.path || currentPath.includes(route.path);
+  return (
+    <ListItem
+      key={`sub-list-${route?.name}`}
+      sx={{ margin: 0, paddingY: 0, pr: 0 }}
+    >
+      <Link
+        to={route.path}
+        style={{
+          textDecoration: "none",
+          margin: 0,
+          padding: 0,
+          color: "inherit",
+          width: "100%",
+        }}
+        activeProps={{
+          style: {
+            color: theme.palette.primary.main,
+            fontWeight: isActive ? "bold" : "normal",
+            width: "100%",
+          },
+        }}
+      >
+        <ListItemButton
+          key={`sub-list-button-${route?.name}`}
+          sx={{
+            width: "100%",
+            marginLeft: "40px",
+            borderLeft: `1px solid ${theme.palette.divider}`,
+            backgroundColor: isActive
+              ? alpha(theme.palette.secondary.main, 0.1)
+              : "inherit",
+          }}
+        >
+          <span
+            key={`sub-list-text-${route?.name}`}
+            style={{
+              color: BCDesignTokens.themeGray100,
+              fontWeight: isActive ? "bold" : "normal",
+            }}
+          >
+            {route.name}
+          </span>
+        </ListItemButton>
+      </Link>
+    </ListItem>
+  );
+};

--- a/centre-web/src/hooks/api/constants.ts
+++ b/centre-web/src/hooks/api/constants.ts
@@ -1,4 +1,5 @@
 export const QUERY_KEY = Object.freeze({
   APPLICATIONS: "applications",
   REQUEST_CATALOG: "request-catalog",
+  USERS: "users",
 });

--- a/centre-web/src/hooks/api/useUsers.ts
+++ b/centre-web/src/hooks/api/useUsers.ts
@@ -1,0 +1,17 @@
+import { centreRequest } from "@/utils/axiosUtils";
+import { useQuery } from "@tanstack/react-query";
+import { QUERY_KEY } from "./constants";
+import { CentreUser } from "@/models/CentreUser";
+
+const getUsers = () => {
+  return centreRequest<CentreUser[]>({
+    url: `users`,
+  });
+};
+
+export const useGetUsers = () => {
+  return useQuery({
+    queryKey: [QUERY_KEY.USERS],
+    queryFn: getUsers,
+  });
+};

--- a/centre-web/src/models/CentreUser.ts
+++ b/centre-web/src/models/CentreUser.ts
@@ -1,0 +1,8 @@
+export type CentreUser = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  username: string;
+  apps: string[];
+};

--- a/centre-web/src/models/KcUser.ts
+++ b/centre-web/src/models/KcUser.ts
@@ -1,0 +1,13 @@
+export type KcUser = {
+  id?: string;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  attributes?: Record<string, string[]>;
+  enabled?: boolean;
+  realmRoles?: string[];
+  clientRoles?: Record<string, string[]>;
+  applicationRoles?: Record<string, string[]>;
+  groups?: string[];
+};

--- a/centre-web/src/models/Roles.ts
+++ b/centre-web/src/models/Roles.ts
@@ -1,0 +1,3 @@
+export enum EpicCentreRoles {
+  manage_requests = "manage_requests",
+}

--- a/centre-web/src/routeTree.gen.ts
+++ b/centre-web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 // Import Routes
 
 import { Route as rootRoute } from './routes/__root'
+import { Route as UnauthenticatedImport } from './routes/unauthenticated'
 import { Route as OidcCallbackImport } from './routes/oidc-callback'
 import { Route as LogoutImport } from './routes/logout'
 import { Route as ErrorImport } from './routes/error'
@@ -19,8 +20,14 @@ import { Route as IndexImport } from './routes/index'
 import { Route as AuthenticatedIndexImport } from './routes/_authenticated/index'
 import { Route as AuthenticatedRequestAccessIndexImport } from './routes/_authenticated/request-access/index'
 import { Route as AuthenticatedLaunchpadIndexImport } from './routes/_authenticated/launchpad/index'
+import { Route as AuthenticatedRequestAccessAuthIndexImport } from './routes/_authenticated/request-access/auth/index'
 
 // Create/Update Routes
+
+const UnauthenticatedRoute = UnauthenticatedImport.update({
+  path: '/unauthenticated',
+  getParentRoute: () => rootRoute,
+} as any)
 
 const OidcCallbackRoute = OidcCallbackImport.update({
   path: '/oidc-callback',
@@ -64,6 +71,12 @@ const AuthenticatedLaunchpadIndexRoute =
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 
+const AuthenticatedRequestAccessAuthIndexRoute =
+  AuthenticatedRequestAccessAuthIndexImport.update({
+    path: '/request-access/auth/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
@@ -103,6 +116,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OidcCallbackImport
       parentRoute: typeof rootRoute
     }
+    '/unauthenticated': {
+      id: '/unauthenticated'
+      path: '/unauthenticated'
+      fullPath: '/unauthenticated'
+      preLoaderRoute: typeof UnauthenticatedImport
+      parentRoute: typeof rootRoute
+    }
     '/_authenticated/': {
       id: '/_authenticated/'
       path: '/'
@@ -124,6 +144,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedRequestAccessIndexImport
       parentRoute: typeof AuthenticatedImport
     }
+    '/_authenticated/request-access/auth/': {
+      id: '/_authenticated/request-access/auth/'
+      path: '/request-access/auth'
+      fullPath: '/request-access/auth'
+      preLoaderRoute: typeof AuthenticatedRequestAccessAuthIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
   }
 }
 
@@ -135,10 +162,12 @@ export const routeTree = rootRoute.addChildren({
     AuthenticatedIndexRoute,
     AuthenticatedLaunchpadIndexRoute,
     AuthenticatedRequestAccessIndexRoute,
+    AuthenticatedRequestAccessAuthIndexRoute,
   }),
   ErrorRoute,
   LogoutRoute,
   OidcCallbackRoute,
+  UnauthenticatedRoute,
 })
 
 /* prettier-ignore-end */
@@ -153,7 +182,8 @@ export const routeTree = rootRoute.addChildren({
         "/_authenticated",
         "/error",
         "/logout",
-        "/oidc-callback"
+        "/oidc-callback",
+        "/unauthenticated"
       ]
     },
     "/": {
@@ -164,7 +194,8 @@ export const routeTree = rootRoute.addChildren({
       "children": [
         "/_authenticated/",
         "/_authenticated/launchpad/",
-        "/_authenticated/request-access/"
+        "/_authenticated/request-access/",
+        "/_authenticated/request-access/auth/"
       ]
     },
     "/error": {
@@ -176,6 +207,9 @@ export const routeTree = rootRoute.addChildren({
     "/oidc-callback": {
       "filePath": "oidc-callback.tsx"
     },
+    "/unauthenticated": {
+      "filePath": "unauthenticated.tsx"
+    },
     "/_authenticated/": {
       "filePath": "_authenticated/index.tsx",
       "parent": "/_authenticated"
@@ -186,6 +220,10 @@ export const routeTree = rootRoute.addChildren({
     },
     "/_authenticated/request-access/": {
       "filePath": "_authenticated/request-access/index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/request-access/auth/": {
+      "filePath": "_authenticated/request-access/auth/index.tsx",
       "parent": "/_authenticated"
     }
   }

--- a/centre-web/src/routes/_authenticated.tsx
+++ b/centre-web/src/routes/_authenticated.tsx
@@ -1,13 +1,17 @@
+import { PageLoader } from "@/components/PageLoader";
 import SideNavBar from "@/components/SideNav/SideNavBar";
 import { OidcConfig } from "@/utils/config";
 import { Box } from "@mui/material";
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
+import { useAuth } from "react-oidc-context";
 
 export const Route = createFileRoute("/_authenticated")({
   beforeLoad: ({ context }) => {
-    const { isAuthenticated, signinRedirect } = context.authentication;
-    if (!isAuthenticated) {
+    const { isAuthenticated, signinRedirect, isLoading } =
+      context.authentication;
+    if (!isAuthenticated && !isLoading) {
       signinRedirect({
+        redirect_uri: window.location.href,
         extraQueryParams: {
           kc_idp_hint: OidcConfig.extraQueryParams?.kc_idp_hint || "",
         },
@@ -18,6 +22,16 @@ export const Route = createFileRoute("/_authenticated")({
 });
 
 function AuthenticatedRoute() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <PageLoader />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/unauthenticated" />;
+  }
+
   return (
     <div>
       <Box flexDirection={"row"} display={"flex"}>

--- a/centre-web/src/routes/_authenticated/request-access/auth/index.tsx
+++ b/centre-web/src/routes/_authenticated/request-access/auth/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/Shared/CentreTabs/CentreTab";
 import { CentreTabPanel } from "@/components/Shared/CentreTabs/CentreTabPanel";
 import { PageContainer } from "@/components/Shared/PageGrid";
-import { Box, Grid, Paper, Tabs, Typography } from "@mui/material";
+import { Box, Grid, Paper, Typography } from "@mui/material";
 import { createFileRoute } from "@tanstack/react-router";
 import { BCDesignTokens } from "epic.theme";
 import { useState } from "react";

--- a/centre-web/src/routes/_authenticated/request-access/auth/index.tsx
+++ b/centre-web/src/routes/_authenticated/request-access/auth/index.tsx
@@ -1,0 +1,80 @@
+import { AllUsers } from "@/components/AuthManagement/AllUsers";
+import { NewRequests } from "@/components/AuthManagement/NewRequests";
+import {
+  CentreTab,
+  CentreTabs,
+} from "@/components/Shared/CentreTabs/CentreTab";
+import { CentreTabPanel } from "@/components/Shared/CentreTabs/CentreTabPanel";
+import { PageContainer } from "@/components/Shared/PageGrid";
+import { Box, Grid, Paper, Tabs, Typography } from "@mui/material";
+import { createFileRoute } from "@tanstack/react-router";
+import { BCDesignTokens } from "epic.theme";
+import { useState } from "react";
+
+export const Route = createFileRoute("/_authenticated/request-access/auth/")({
+  component: AuthRequestAccess,
+});
+
+function AuthRequestAccess() {
+  const [value, setValue] = useState(0);
+
+  const handleChange = (_: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+  return (
+    <PageContainer>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Paper elevation={1}>
+            <Box
+              sx={{
+                padding: "12px 24px",
+              }}
+            >
+              <Typography variant="h3" fontWeight={"bold"}>
+                EPIC.auth
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                padding: "12px",
+              }}
+            >
+              <Box
+                sx={{
+                  padding: "16px",
+                  border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
+                }}
+              >
+                <CentreTabs
+                  value={value}
+                  onChange={handleChange}
+                  TabIndicatorProps={{ sx: { display: "none" } }}
+                >
+                  <CentreTab
+                    label="New Access Requests"
+                    sx={{
+                      width: "205px",
+                    }}
+                  />
+                  <CentreTab
+                    label="All Users"
+                    sx={{
+                      width: "105px",
+                    }}
+                  />
+                </CentreTabs>
+                <CentreTabPanel value={value} index={0}>
+                  <NewRequests />
+                </CentreTabPanel>
+                <CentreTabPanel value={value} index={1}>
+                  <AllUsers />
+                </CentreTabPanel>
+              </Box>
+            </Box>
+          </Paper>
+        </Grid>
+      </Grid>
+    </PageContainer>
+  );
+}

--- a/centre-web/src/routes/unauthenticated.tsx
+++ b/centre-web/src/routes/unauthenticated.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export const Route = createFileRoute("/unauthenticated")({
+  component: Unauthenticated,
+});
+
+function Unauthenticated() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigate({ to: "/login" });
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
+  return (
+    <div>You need to login to view this page. Redirecting to login...</div>
+  );
+}

--- a/centre-web/src/stores/authPageStore.ts
+++ b/centre-web/src/stores/authPageStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type TabStore = {
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+};
+
+export const useTabStore = create<TabStore>((set) => ({
+  activeTab: "",
+  setActiveTab: (tab) => set({ activeTab: tab }),
+}));

--- a/centre-web/src/utils/config.ts
+++ b/centre-web/src/utils/config.ts
@@ -35,6 +35,7 @@ export const AppConfig = {
   version: APP_VERSION,
   appTitle: APP_TITLE,
   documentSearchUrl: DOCUMENT_SEARCH_URL,
+  clientId: CLIENT_ID,
 };
 
 export const OidcConfig = {


### PR DESCRIPTION
Adds functionality for user management including retrieving users with application access information.

This includes:
- Exposing a new `users` API endpoint to retrieve user data.
- Creating a user schema to serialize user data.
- Implementing a service to fetch users from the Auth API and enrich them with assigned applications.
- Adding UI components to display and search users.

Relates to CENTRE-task#29