### PR TITLE
CENTR-56:Truncated bookmark names should end with an ellipsis

### DIFF
--- a/centre-web/src/components/LaunchAppTile/BookmarkSection.tsx
+++ b/centre-web/src/components/LaunchAppTile/BookmarkSection.tsx
@@ -71,22 +71,27 @@ export const BookmarkSection = ({ epicApp }: BookmarkSectionProps) => {
                   <CentreLink
                     key={bookmark.label}
                     onClick={() => window.open(bookmark.url, "_blank")}
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
                   >
+                    {bookmark.label && bookmark.label.length > 0 && (
+                      <Circle sx={{ marginRight: "5px", fontSize: "7px", flexShrink: 0 }} />
+                    )}
                     <Typography
                       variant="body1"
                       fontWeight={400}
                       color={"inherit"}
                       sx={{
-                        overflow: "clip",
+                        overflow: "hidden",
                         textOverflow: "ellipsis",
                         whiteSpace: "nowrap",
-                        display: "flex",
-                        alignItems: "center",
                       }}
                     >
-                      {bookmark.label && bookmark.label.length > 0 && (
-                        <Circle sx={{  marginRight: "5px", fontSize: "7px" }} />
-                      )}
                       {bookmark.label}
                     </Typography>
                   </CentreLink>


### PR DESCRIPTION
Description:
This update ensures that long bookmark names are truncated with an ellipsis (...) to maintain a clean and consistent UI layout.

Changes Included:
- Implemented truncation style for bookmark names exceeding the defined character limit.