### PR TITLE
Refines admin filtering for applications and requests

### DIFF
--- a/centre-api/src/centre_api/enums/epic_app.py
+++ b/centre-api/src/centre_api/enums/epic_app.py
@@ -95,6 +95,7 @@ GROUP_TO_APP_NAME_MAP = {
     'COMPLIANCE': 'epic_compliance',
     'CONDITION-REPO': 'condition_repository',
     'ENGAGE': 'epic_engage',
+    'CENTRE': 'epic_centre',
 }
 
 CLIENT_APP_NAME_TO_ADMIN_ROLES_MAP = {
@@ -103,5 +104,5 @@ CLIENT_APP_NAME_TO_ADMIN_ROLES_MAP = {
     EpicAppClientName.EPIC_ENGAGE.value: ['create_admin_user'],
     EpicAppClientName.EPIC_COMPLIANCE.value: ['super_user'],
     EpicAppClientName.CONDITION_REPOSITORY.value: [''],
-    EpicAppClientName.EPIC_SUBMIT.value: ['manage_auth'],
+    EpicAppClientName.EPIC_SUBMIT.value: ['manage-users'],
 }

--- a/centre-api/src/centre_api/services/access_requests.py
+++ b/centre-api/src/centre_api/services/access_requests.py
@@ -34,8 +34,18 @@ class AccessRequestsService:
             **args,
             'user_auth_guid': user_auth_guid
         })
+        is_dst_admin = TokenInfo.has_admin_roles(EpicAppClientName.EPIC_CENTRE.value)
+        admin_roles_map = TokenInfo.get_admin_roles_map()
+        filtered_requests = [
+            req for req in access_requests
+            if is_dst_admin or admin_roles_map.get(
+                APP_NAME_TO_CLIENT_NAME_MAP.get(req.app.name),
+                False
+            )
+        ]
+
         user = AuthApiService.get_user_by_id(user_auth_guid)
-        serialized_requests = [req.to_dict() for req in access_requests]
+        serialized_requests = [req.to_dict() for req in filtered_requests]
         for req in serialized_requests:
             req['user'] = user
         return serialized_requests

--- a/centre-api/src/centre_api/services/user_service.py
+++ b/centre-api/src/centre_api/services/user_service.py
@@ -39,17 +39,17 @@ class UserService:
     @staticmethod
     def _enrich_user_with_apps(user):
         """Enrich a single user dictionary with app names and highest level roles based on their groups."""
-        app_roles = defaultdict(lambda: {'level': float('-inf'), 'role': None, 'group_name': None})
+        app_roles = defaultdict(lambda: {'level': float('-inf'), 'role': None, 'group_name': None, 'group_path': None})
 
+        current_user_is_dst_admin = TokenInfo.has_admin_roles(EpicAppClientName.EPIC_CENTRE.value)
+        current_user_admin_roles_map = TokenInfo.get_admin_roles_map()
         for group in user.get('groups', []):
             path = group.get('path', '')
             level = group.get('level', float('-inf'))
             display_name = group.get('display_name', '')
             top_path = path.split('/')[0]
             app_name = GROUP_TO_APP_NAME_MAP.get(top_path)
-
             if app_name:
-                # Check if this group has a higher level for the app
                 if level > app_roles[app_name]['level']:
                     app_roles[app_name] = {
                         'level': level,
@@ -58,25 +58,29 @@ class UserService:
                         'group_path': path
                     }
 
-        # Initialize all apps from GROUP_TO_APP_NAME_MAP with defaults
-        all_apps = {}
-        for _, app_name in GROUP_TO_APP_NAME_MAP.items():
+        for app_name in GROUP_TO_APP_NAME_MAP.values():
             if app_name not in app_roles:
-                all_apps[app_name] = {
-                    'level': float('-inf'),
+                app_roles[app_name] = {
+                    'level': None,
                     'role': None,
-                    'group_name': None
+                    'group_name': None,
+                    'group_path': None
                 }
-            else:
-                all_apps[app_name] = app_roles[app_name]
 
-        # Construct the apps field as required
-        user['apps'] = [
-            {'name': app_name, 'role': role_info['role'],
-             'group_name': role_info['group_name'], 'group_path': role_info['group_path']}
+        apps = [
+            {'name': app_name, 'role': role_info.get('role'),
+             'group_name': role_info.get('group_name'), 'group_path': role_info.get('group_path')}
             for app_name, role_info in sorted(app_roles.items())
         ]
 
+        filtered_apps = [
+            app for app in apps
+            if current_user_is_dst_admin or current_user_admin_roles_map.get(
+                APP_NAME_TO_CLIENT_NAME_MAP.get(app['name']), False
+            )
+        ]
+
+        user['apps'] = filtered_apps
         return user
 
     @classmethod
@@ -111,8 +115,8 @@ class UserService:
     @classmethod
     def has_admin_access_on_app(cls, app_name: str):
         """Check if the user had admin access on the given app."""
-        had_dst_admin_roles = TokenInfo.has_admin_roles(EpicAppClientName.EPIC_CENTRE.value)
-        if had_dst_admin_roles:
+        has_dst_admin_roles = TokenInfo.has_admin_roles(EpicAppClientName.EPIC_CENTRE.value)
+        if has_dst_admin_roles:
             return True
 
         client_name = APP_NAME_TO_CLIENT_NAME_MAP.get(app_name)

--- a/centre-api/src/centre_api/utils/token_info.py
+++ b/centre-api/src/centre_api/utils/token_info.py
@@ -42,3 +42,16 @@ class TokenInfo:
         roles = client_resource_access.get('roles', [])
         admin_roles = CLIENT_APP_NAME_TO_ADMIN_ROLES_MAP.get(client_name, [])
         return any(role in admin_roles for role in roles)
+
+    @staticmethod
+    def get_admin_roles_map():
+        """Check if the user has admin roles for the given client."""
+        token_info = g.jwt_oidc_token_info
+        resource_access = token_info.get('resource_access', {})
+        admin_roles_map = {}
+        for client, access in resource_access.items():
+            roles = access.get('roles', [])
+            admin_roles = CLIENT_APP_NAME_TO_ADMIN_ROLES_MAP.get(client, [])
+            admin_roles_map[client] = any(role in admin_roles for role in roles)
+
+        return admin_roles_map

--- a/centre-web/src/components/AuthManagement/UserAccess/CurrentAccessLevel/CurrentAccessTable.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/CurrentAccessLevel/CurrentAccessTable.tsx
@@ -76,9 +76,8 @@ export const CurrentAccessTable = ({ user }: CurrentAccessTableProps) => {
 
   const apps = useMemo(() => {
     const userApps = user?.apps || [];
-    const appsWithRoles = getAllAppsWithRoles(userApps);
 
-    return appsWithRoles.map((app) => ({
+    return userApps.map((app) => ({
       ...app,
       supportsGranularRoleManagement:
         appSupportsGranularRoleManagementMap.get(app.name) ?? false,

--- a/centre-web/src/components/AuthManagement/UserAccess/CurrentAccessLevel/CurrentAccessTable.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/CurrentAccessLevel/CurrentAccessTable.tsx
@@ -8,7 +8,6 @@ import { CentreUser, CentreUserApp } from "@/models/CentreUser";
 import { Table, TableBody, TableContainer, TableRow } from "@mui/material";
 import { getAppChipTitle } from "../../utils";
 import { useMemo, useRef } from "react";
-import { getAllAppsWithRoles } from "./utils";
 import { useModal } from "@/components/Shared/Modals/modalStore";
 import { EditAccessModal } from "../../EditAccess";
 import { useAppConfigs } from "@/hooks/api/useAppConfigs";

--- a/centre-web/src/models/EpicApp.ts
+++ b/centre-web/src/models/EpicApp.ts
@@ -33,6 +33,63 @@ export enum EpicAppName {
   EPIC_CENTRE = "epic_centre",
 }
 
+export enum EpicAppClientName {
+  CONDITION_REPOSITORY = "epic-condition",
+  EPIC_COMPLIANCE = "epic-compliance",
+  EPIC_TRACK = "epictrack-web",
+  EPIC_PUBLIC = "epic-public",
+  EPIC_SUBMIT = "epic-submit",
+  EPIC_ENGAGE = "epic-engage",
+  EPIC_CENTRE = "epic-centre",
+  DOCUMENT_SEARCH = "",
+}
+
+/**
+ * Bi-directional mappings between canonical EpicAppName and client-facing EpicAppClientName.
+ * Use toClientName / toEpicAppName helpers for safe conversions.
+ */
+export const EPIC_APP_NAME_TO_CLIENT_NAME: Readonly<
+  Record<EpicAppName, EpicAppClientName>
+> = {
+  [EpicAppName.CONDITION_REPOSITORY]: EpicAppClientName.CONDITION_REPOSITORY,
+  [EpicAppName.EPIC_COMPLIANCE]: EpicAppClientName.EPIC_COMPLIANCE,
+  [EpicAppName.DOCUMENT_SEARCH]:
+    EpicAppClientName.DOCUMENT_SEARCH ?? ("" as any), // preserve shape if missing
+  [EpicAppName.EPIC_TRACK]: EpicAppClientName.EPIC_TRACK,
+  [EpicAppName.EPIC_PUBLIC]: EpicAppClientName.EPIC_PUBLIC,
+  [EpicAppName.EPIC_SUBMIT]: EpicAppClientName.EPIC_SUBMIT,
+  [EpicAppName.EPIC_ENGAGE]: EpicAppClientName.EPIC_ENGAGE,
+  [EpicAppName.EPIC_CENTRE]: EpicAppClientName.EPIC_CENTRE,
+};
+
+/**
+ * Reverse mapping derived from EPIC_APP_NAME_TO_CLIENT_NAME.
+ */
+export const EPIC_APP_CLIENT_NAME_TO_NAME: Readonly<
+  Record<EpicAppClientName, EpicAppName>
+> = Object.freeze(
+  Object.keys(EPIC_APP_NAME_TO_CLIENT_NAME).reduce(
+    (acc, key) => {
+      const name = key as EpicAppName;
+      const client = EPIC_APP_NAME_TO_CLIENT_NAME[name];
+      if (client) {
+        (acc as any)[client] = name;
+      }
+      return acc;
+    },
+    {} as Record<EpicAppClientName, EpicAppName>,
+  ),
+);
+
+/** Convert canonical name -> client name (always defined) */
+export const toClientName = (name: EpicAppName): EpicAppClientName =>
+  EPIC_APP_NAME_TO_CLIENT_NAME[name];
+
+/** Convert client name -> canonical name (may be undefined if unknown) */
+export const toEpicAppName = (
+  client: EpicAppClientName,
+): EpicAppName | undefined => EPIC_APP_CLIENT_NAME_TO_NAME[client];
+
 export enum RequestAccessStatus {
   ACCESSED = "accessed",
   PENDING = "pending",

--- a/centre-web/src/utils/roleUtils.ts
+++ b/centre-web/src/utils/roleUtils.ts
@@ -1,6 +1,12 @@
 import { getUserRolesFromToken } from "@/components/Shared/PermissionGate/utils";
 import { jwtDecode } from "jwt-decode";
 import { EPIC_ADMIN_ROLES } from "./constants";
+import {
+  EPIC_APP_NAME_TO_CLIENT_NAME,
+  EpicAppClientName,
+  EpicAppName,
+  toEpicAppName,
+} from "@/models/EpicApp";
 
 /**
  * Get user groups from JWT token
@@ -9,7 +15,7 @@ import { EPIC_ADMIN_ROLES } from "./constants";
  */
 export const getUserGroupsFromToken = (accessToken?: string): string[] => {
   if (!accessToken) return [];
-  
+
   try {
     const tokenData: any = jwtDecode(accessToken);
     return tokenData?.groups || [];
@@ -23,9 +29,11 @@ export const getUserGroupsFromToken = (accessToken?: string): string[] => {
  * @param accessToken - The user's access token
  * @returns resource_access object containing roles for each client
  */
-export const getResourceAccessFromToken = (accessToken?: string): Record<string, { roles: string[] }> => {
+export const getResourceAccessFromToken = (
+  accessToken?: string,
+): Record<string, { roles: string[] }> => {
   if (!accessToken) return {};
-  
+
   try {
     const tokenData: any = jwtDecode(accessToken);
     return tokenData?.resource_access || {};
@@ -35,27 +43,40 @@ export const getResourceAccessFromToken = (accessToken?: string): Record<string,
 };
 
 /**
- * Check if a user has admin role in any Epic application
- * Checks resource_access for each client to see if user has admin roles
+ * Get admin status per Epic application
+ * Returns an object with app name keys and boolean values indicating admin status
  * @param accessToken - The user's access token
- * @returns boolean indicating if user has admin role in any Epic app
+ * @returns Record<EpicAppName, boolean> mapping each app to whether the user is an admin
  */
-export const hasAdminRoleInAnyApp = (accessToken?: string): boolean => {
-  if (!accessToken) return false;
-  
+export const getAdminStatusPerApp = (
+  accessToken?: string,
+): Record<EpicAppName, boolean> => {
+  // initialize result with canonical app names
+  const result: Record<EpicAppName, boolean> = Object.keys(
+    EPIC_APP_NAME_TO_CLIENT_NAME,
+  ).reduce(
+    (acc, name) => {
+      acc[name as EpicAppName] = false;
+      return acc;
+    },
+    {} as Record<EpicAppName, boolean>,
+  );
+
+  if (!accessToken) return result;
+
   const resourceAccess = getResourceAccessFromToken(accessToken);
-  
-  // Check each Epic client for admin roles
+
   for (const [clientName, adminRoles] of Object.entries(EPIC_ADMIN_ROLES)) {
+    const appName = toEpicAppName(clientName as EpicAppClientName);
+    if (!appName) continue;
+
     const clientRoles = resourceAccess[clientName]?.roles || [];
-    
-    // If user has any admin role for this client, grant access
-    if (adminRoles.some(adminRole => clientRoles.includes(adminRole))) {
-      return true;
-    }
+    result[appName] = adminRoles.some((adminRole) =>
+      clientRoles.includes(adminRole),
+    );
   }
-  
-  return false;
+
+  return result;
 };
 
 /**
@@ -65,7 +86,9 @@ export const hasAdminRoleInAnyApp = (accessToken?: string): boolean => {
  * @returns boolean indicating if user can access EPIC.auth pages
  */
 export const isAdministrator = (accessToken?: string): boolean => {
-  return hasAdminRoleInAnyApp(accessToken);
+  return Object.values(getAdminStatusPerApp(accessToken)).some(
+    (isAdmin) => isAdmin,
+  );
 };
 
 /**
@@ -74,10 +97,12 @@ export const isAdministrator = (accessToken?: string): boolean => {
  * @param requiredRoles - Array of required roles
  * @returns boolean indicating if user has at least one of the roles
  */
-export const hasAnyRole = (requiredRoles: string[], accessToken?: string): boolean => {
+export const hasAnyRole = (
+  requiredRoles: string[],
+  accessToken?: string,
+): boolean => {
   if (!accessToken || !requiredRoles.length) return false;
-  
-  const roles = getUserRolesFromToken(accessToken);
-  return requiredRoles.some(role => roles.includes(role));
-};
 
+  const roles = getUserRolesFromToken(accessToken);
+  return requiredRoles.some((role) => roles.includes(role));
+};


### PR DESCRIPTION
Enhances both backend and frontend systems to provide more granular control and visibility for administrators. This update ensures that administrators only view applications and access requests for which they have specific administrative privileges, rather than having broad access across all applications.

Key changes include:
- Introduces `epic_centre` to the application mapping for administrative purposes.
- Implements server-side filtering for access requests, limiting visibility to those relevant to the current user's administrative roles.
- Filters the list of applications displayed to a user based on their specific administrative permissions for each app.
- Adds backend utility to map and check admin roles per client, enabling more precise access control.
- Updates frontend components to consume the pre-filtered data from the backend and establishes clear mappings between Epic app names and client names.

CENTRE-task#55