### PR TITLE
CENTRE-task#66: Adds partial user update endpoint

### DIFF
--- a/centre-api/src/centre_api/resources/users.py
+++ b/centre-api/src/centre_api/resources/users.py
@@ -65,7 +65,7 @@ class UserByUsername(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description='Update user status')
     @auth.require
     def patch(username):
-        """Partially update a user."""
+        """Update a user by username."""
         patch_data = request.get_json()
         updated_user = UserService.update_user_status(username, patch_data)
         return UserSchema().dump(updated_user), HTTPStatus.OK

--- a/centre-api/src/centre_api/resources/users.py
+++ b/centre-api/src/centre_api/resources/users.py
@@ -61,6 +61,15 @@ class UserByUsername(Resource):
             return {'message': 'User not found'}, HTTPStatus.NOT_FOUND
         return UserSchema().dump(user), HTTPStatus.OK
 
+    @staticmethod
+    @ApiHelper.swagger_decorators(API, endpoint_description='Update user status')
+    @auth.require
+    def patch(username):
+        """Partially update a user."""
+        patch_data = request.get_json()
+        updated_user = UserService.update_user_status(username, patch_data)
+        return UserSchema().dump(updated_user), HTTPStatus.OK
+
 
 @cors_preflight('PUT, OPTIONS, DELETE')
 @API.route('/<username>/access', methods=['PUT', 'OPTIONS', 'DELETE'])

--- a/centre-api/src/centre_api/services/auth_api_service.py
+++ b/centre-api/src/centre_api/services/auth_api_service.py
@@ -174,3 +174,30 @@ class AuthApiService:
         except requests.RequestException as error:
             current_app.logger.error(f'Error deleting user group mappings: {error}')
             raise error
+
+    @staticmethod
+    def patch_user(username: str, patch_data: dict):
+        """Patch a user's information in the Auth API.
+
+        This forwards a partial update to EPIC.auth's PATCH /users/<username> endpoint.
+
+        :param username: The user's Keycloak username
+        :param patch_data: Dictionary of allowed fields (e.g. 'enabled', 'attributes')
+        :return: The updated user dict
+        """
+        try:
+            base_url = f'{os.getenv("AUTH_API")}/api/users/{username}'
+
+            headers = {
+                'Content-Type': 'application/json',
+                'Authorization': g.authorization_header,
+            }
+
+            timeout = current_app.config.get('CONNECT_TIMEOUT', 30)
+            response = requests.patch(base_url, headers=headers, timeout=timeout, json=patch_data)
+            response.raise_for_status()
+
+            return response.json()
+        except requests.RequestException as error:
+            current_app.logger.error(f'Error patching user "{username}": {error}')
+            raise error

--- a/centre-api/src/centre_api/services/user_service.py
+++ b/centre-api/src/centre_api/services/user_service.py
@@ -121,3 +121,16 @@ class UserService:
 
         client_name = APP_NAME_TO_CLIENT_NAME_MAP.get(app_name)
         return TokenInfo.has_admin_roles(client_name)
+
+    @classmethod
+    def update_user_status(cls, username: str, patch_data: dict):
+        """Update user status (enabled,firstName, etc.) via EPIC.auth.
+
+        This wraps the patch_user call to allow access from resource layer.
+        Allowed keys should match EPIC.auth's whitelist.
+
+        :param username: Keycloak username
+        :param patch_data: Dict of fields to update (e.g. {"enabled": True})
+        :return: Updated user dict
+        """
+        return AuthApiService.patch_user(username, patch_data)


### PR DESCRIPTION
Adds a new API endpoint to allow partial updates for user information.

Introduces a `PATCH` method to `/users/` that supports updating specific user attributes, such as their `enabled` status. Integrates with the external Auth API via a new `patch_user` service method to forward these partial updates, ensuring consistency with the central authentication system.