### PR TITLE
CENTRE-task#66: Enables user account activation/deactivation

### DIFF
--- a/centre-api/src/centre_api/resources/users.py
+++ b/centre-api/src/centre_api/resources/users.py
@@ -65,7 +65,7 @@ class UserByUsername(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description='Update user status')
     @auth.require
     def patch(username):
-        """Partially update a user."""
+        """Update a user by username."""
         patch_data = request.get_json()
         updated_user = UserService.update_user_status(username, patch_data)
         return UserSchema().dump(updated_user), HTTPStatus.OK

--- a/centre-api/src/centre_api/resources/users.py
+++ b/centre-api/src/centre_api/resources/users.py
@@ -61,6 +61,15 @@ class UserByUsername(Resource):
             return {'message': 'User not found'}, HTTPStatus.NOT_FOUND
         return UserSchema().dump(user), HTTPStatus.OK
 
+    @staticmethod
+    @ApiHelper.swagger_decorators(API, endpoint_description='Update user status')
+    @auth.require
+    def patch(username):
+        """Partially update a user."""
+        patch_data = request.get_json()
+        updated_user = UserService.update_user_status(username, patch_data)
+        return UserSchema().dump(updated_user), HTTPStatus.OK
+
 
 @cors_preflight('PUT, OPTIONS, DELETE')
 @API.route('/<username>/access', methods=['PUT', 'OPTIONS', 'DELETE'])

--- a/centre-api/src/centre_api/resources/users.py
+++ b/centre-api/src/centre_api/resources/users.py
@@ -46,8 +46,8 @@ class Users(Resource):
         return UserSchema(many=True).dump(users), HTTPStatus.OK
 
 
-@cors_preflight('GET, OPTIONS')
-@API.route('/username/<username>', methods=['GET', 'OPTIONS'])
+@cors_preflight('GET, OPTIONS, PATCH')
+@API.route('/username/<username>', methods=['GET', 'OPTIONS', 'PATCH'])
 class UserByUsername(Resource):
     """Resource for fetching users."""
 
@@ -67,8 +67,8 @@ class UserByUsername(Resource):
     def patch(username):
         """Update a user by username."""
         patch_data = request.get_json()
-        updated_user = UserService.update_user_status(username, patch_data)
-        return UserSchema().dump(updated_user), HTTPStatus.OK
+        UserService.update_user_status(username, patch_data)
+        return 'User updated', HTTPStatus.OK
 
 
 @cors_preflight('PUT, OPTIONS, DELETE')

--- a/centre-api/src/centre_api/services/auth_api_service.py
+++ b/centre-api/src/centre_api/services/auth_api_service.py
@@ -174,3 +174,30 @@ class AuthApiService:
         except requests.RequestException as error:
             current_app.logger.error(f'Error deleting user group mappings: {error}')
             raise error
+
+    @staticmethod
+    def patch_user(username: str, patch_data: dict):
+        """Patch a user's information in the Auth API.
+
+        This forwards a partial update to EPIC.auth's PATCH /users/<username> endpoint.
+
+        :param username: The user's Keycloak username
+        :param patch_data: Dictionary of allowed fields (e.g. 'enabled', 'attributes')
+        :return: The updated user dict
+        """
+        try:
+            base_url = f'{os.getenv("AUTH_API")}/api/users/{username}'
+
+            headers = {
+                'Content-Type': 'application/json',
+                'Authorization': g.authorization_header,
+            }
+
+            timeout = current_app.config.get('CONNECT_TIMEOUT', 30)
+            response = requests.patch(base_url, headers=headers, timeout=timeout, json=patch_data)
+            response.raise_for_status()
+
+            return response.json()
+        except requests.RequestException as error:
+            current_app.logger.error(f'Error patching user "{username}": {error}')
+            raise error

--- a/centre-api/src/centre_api/services/auth_api_service.py
+++ b/centre-api/src/centre_api/services/auth_api_service.py
@@ -197,7 +197,7 @@ class AuthApiService:
             response = requests.patch(base_url, headers=headers, timeout=timeout, json=patch_data)
             response.raise_for_status()
 
-            return response.json()
+            return
         except requests.RequestException as error:
             current_app.logger.error(f'Error patching user "{username}": {error}')
             raise error

--- a/centre-api/src/centre_api/services/user_service.py
+++ b/centre-api/src/centre_api/services/user_service.py
@@ -121,3 +121,16 @@ class UserService:
 
         client_name = APP_NAME_TO_CLIENT_NAME_MAP.get(app_name)
         return TokenInfo.has_admin_roles(client_name)
+
+    @classmethod
+    def update_user_status(cls, username: str, patch_data: dict):
+        """Update user status (enabled,firstName, etc.) via EPIC.auth.
+
+        This wraps the patch_user call to allow access from resource layer.
+        Allowed keys should match EPIC.auth's whitelist.
+
+        :param username: Keycloak username
+        :param patch_data: Dict of fields to update (e.g. {"enabled": True})
+        :return: Updated user dict
+        """
+        return AuthApiService.patch_user(username, patch_data)

--- a/centre-web/src/components/AuthManagement/EditAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/EditAccess/index.tsx
@@ -47,12 +47,10 @@ export const EditAccessModal = ({
     app.group_path ?? null,
   );
 
-  const {
-    data: accessLevels = [],
-    isLoading: accessLevelsLoading,
-  } = useGeteApplicationAccessLevels({
-    appName: app.name,
-  });
+  const { data: accessLevels = [], isLoading: accessLevelsLoading } =
+    useGeteApplicationAccessLevels({
+      appName: app.name,
+    });
 
   const handleClose = () => {
     setClose();
@@ -69,7 +67,11 @@ export const EditAccessModal = ({
   const currentRole = app.role;
 
   const handleConfirm = async () => {
-    const success = await executeAction(selectedRole, accessLevels, request?.id);
+    const success = await executeAction(
+      selectedRole,
+      accessLevels,
+      request?.id,
+    );
     if (success) {
       await refetch();
     }

--- a/centre-web/src/components/AuthManagement/UserAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/index.tsx
@@ -1,21 +1,43 @@
 import { GreenBadge, GreyBadge } from "@/components/Shared/Badges";
 import BarTitle from "@/components/Shared/BarTitle.tsx";
-import { Box, Grid, Stack, Typography } from "@mui/material";
+import { Box, Button, Grid, Stack, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import { NewAccessRequests } from "./NewAccessRequests";
 import { CurrentAccessLevel } from "./CurrentAccessLevel";
-import { useGetUser } from "@/hooks/api/useUsers";
+import { useGetUser, useUpdateUser } from "@/hooks/api/useUsers";
 import { useParams } from "@tanstack/react-router";
 import { UserAccessSkeleton } from "./UserAccessSkeleton";
+import { LoadingButton } from "@/components/Shared/LoadingButton";
+import { useState } from "react";
 
 export const UserAccess = () => {
   const { username } = useParams({
     from: "/_authenticated/request-access/auth/users/$username",
   });
-  const { data: user, isPending } = useGetUser({
+  const {
+    data: user,
+    isPending,
+    refetch: refetchUser,
+  } = useGetUser({
     username: String(username),
     enabled: !!username,
   });
+
+  const { mutateAsync: updateUser } = useUpdateUser();
+
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const handleEnableUser = async (enable: boolean) => {
+    if (!user) return;
+    setIsUpdating(true);
+    await updateUser({
+      username: user.username,
+      enabled: enable,
+    });
+
+    await refetchUser();
+    setIsUpdating(false);
+  };
 
   if (isPending) {
     return <UserAccessSkeleton />;
@@ -60,6 +82,21 @@ export const UserAccess = () => {
               </Typography>
             </Stack>
           </Grid>
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          container
+          alignItems={"flex-end"}
+          justifyContent={"flex-end"}
+        >
+          <LoadingButton
+            variant="outlined"
+            onClick={() => handleEnableUser(!user?.enabled)}
+            loading={isUpdating}
+          >
+            {user?.enabled ? "Disable User" : "Enable User"}
+          </LoadingButton>
         </Grid>
         <Grid item xs={12} mt={"24px"}>
           <NewAccessRequests user={user} />

--- a/centre-web/src/components/AuthManagement/UserAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/index.tsx
@@ -1,6 +1,6 @@
 import { GreenBadge, GreyBadge } from "@/components/Shared/Badges";
 import BarTitle from "@/components/Shared/BarTitle.tsx";
-import { Box, Button, Grid, Stack, Typography } from "@mui/material";
+import { Box, Grid, Stack, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import { NewAccessRequests } from "./NewAccessRequests";
 import { CurrentAccessLevel } from "./CurrentAccessLevel";

--- a/centre-web/src/hooks/api/useUsers.ts
+++ b/centre-web/src/hooks/api/useUsers.ts
@@ -103,3 +103,32 @@ export const useRevokeUserAccess = (options?: UseRevokeUserAccessOptions) => {
     ...options,
   });
 };
+
+type UpdateUserParams = {
+  username: string;
+  enabled?: boolean;
+  firstName?: string;
+  lastName?: string;
+};
+
+export const updateUser = (params: UpdateUserParams) => {
+  const { username, ...data } = params;
+  return centreRequest<CentreUser>({
+    url: `users/username/${username}`,
+    method: "PATCH",
+    data,
+  });
+};
+
+type UseUpdateUserOptions = UseMutationOptions<
+  CentreUser,
+  unknown,
+  UpdateUserParams
+>;
+
+export const useUpdateUser = (options?: UseUpdateUserOptions) => {
+  return useMutation({
+    mutationFn: (params: UpdateUserParams) => updateUser(params),
+    ...options,
+  });
+};


### PR DESCRIPTION
Adds the capability for administrators to enable or disable user accounts directly from the application.

- Implements a new `PATCH /users/username/` API endpoint to allow partial user updates, specifically for modifying the user's `enabled` status.
- Integrates with the external Auth API to forward these user patch requests.
- Introduces a "Disable User" / "Enable User" button on the User Access page in the frontend, consuming the new API to toggle a user's account status.
- Updates the UI to reflect the current user status and reloads user data after an update.

This enhancement provides greater control and flexibility in managing user access.