### PR TITLE
CENTR-57:Home Page

### DIFF
--- a/centre-web/src/components/Home/HomePage.tsx
+++ b/centre-web/src/components/Home/HomePage.tsx
@@ -1,12 +1,8 @@
-import { Button, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { Box } from "@mui/system";
 import { PageContainer } from "@/components/Shared/PageGrid";
 
-type HomePageProps = Readonly<{
-  onSignIn: () => void;
-}>;
-
-export default function HomePage({ onSignIn }: HomePageProps) {
+export default function HomePage() {
   return (
     <PageContainer
       display="flex"

--- a/centre-web/src/components/Home/HomePage.tsx
+++ b/centre-web/src/components/Home/HomePage.tsx
@@ -1,0 +1,35 @@
+import { Button, Typography } from "@mui/material";
+import { Box } from "@mui/system";
+import { PageContainer } from "@/components/Shared/PageGrid";
+
+type HomePageProps = Readonly<{
+  onSignIn: () => void;
+}>;
+
+export default function HomePage({ onSignIn }: HomePageProps) {
+  return (
+    <PageContainer
+      display="flex"
+      flexDirection="column"
+      sx={{
+        background:
+          "linear-gradient(180deg, rgba(233, 246, 255, 0.75) 0%, rgba(255, 255, 255, 1) 45%)",
+        overflowX: "hidden",
+        boxSizing: "border-box",
+      }}
+    >
+      <Box
+        maxWidth={720}
+        width="100%"
+        display="flex"
+        flexDirection="column"
+      >
+        <Typography variant="h2" component="h1">
+          EPIC.centre
+        </Typography>
+      </Box>
+
+    </PageContainer>
+  );
+}
+

--- a/centre-web/src/components/Layout/EAOAppBar.tsx
+++ b/centre-web/src/components/Layout/EAOAppBar.tsx
@@ -2,10 +2,18 @@ import { AppBar, Box, Grid } from "@mui/material";
 import EAO_Logo from "@/assets/images/EAO_Logo.png";
 import { BCDesignTokens } from "epic.theme";
 import { useNavigate } from "@tanstack/react-router";
+import { useAuth } from "react-oidc-context";
 import AppBarActions from "./AppBarActions";
 
 export default function EAOAppBar() {
   const navigate = useNavigate();
+  const auth = useAuth();
+
+  const handleLogoClick = () => {
+    navigate({
+      to: auth.isAuthenticated ? "/launchpad/" : "/",
+    });
+  };
 
   return (
     <AppBar
@@ -26,11 +34,7 @@ export default function EAOAppBar() {
           display="flex"
           justifyContent="start"
           alignItems="center"
-          onClick={() =>
-            navigate({
-              to: `/launchpad`,
-            })
-          }
+          onClick={handleLogoClick}
           sx={{
             cursor: "pointer",
           }}

--- a/centre-web/src/routes/index.tsx
+++ b/centre-web/src/routes/index.tsx
@@ -1,7 +1,6 @@
+import HomePage from "@/components/Home/HomePage";
 import { PageLoader } from "@/components/PageLoader";
-
-import { createFileRoute, Navigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { createFileRoute } from "@tanstack/react-router";
 import { useAuth } from "react-oidc-context";
 
 export const Route = createFileRoute("/")({
@@ -9,17 +8,13 @@ export const Route = createFileRoute("/")({
 });
 
 function Index() {
-  const { isAuthenticated, isLoading, signinRedirect } = useAuth();
+  const {isLoading, signinRedirect } = useAuth();
 
-  useEffect(() => {
-    if (!isAuthenticated && !isLoading) {
-      signinRedirect();
-    }
-  }, [isAuthenticated, isLoading, signinRedirect]);
-
-  if (isAuthenticated) {
-    return <Navigate to="/oidc-callback" />;
+  if (isLoading) {
+    return <PageLoader />;
   }
 
-  return <PageLoader />;
+
+
+  return <HomePage onSignIn={() => signinRedirect()} />;
 }


### PR DESCRIPTION
Description:
Creating a placeholder page for the home page and implementing the router logic.

Changes Included :
- Introduce HomePage component under src/components/Home/ to provide a dedicated landing layout with the EPIC.centre hero treatment inside the shared PageContainer.

- Wire the root / route to render the new component once the OIDC context finishes bootstrapping, while keeping the existing loader during auth initialization.

- Keep the home view callback-driven so a future sign-in CTA can trigger the supplied onSignIn() handler without duplicating auth logic.