### PR TITLE
CENTR-68:Logout doesnt work

### DIFF
--- a/centre-web/src/components/Layout/AppBarActions.tsx
+++ b/centre-web/src/components/Layout/AppBarActions.tsx
@@ -32,6 +32,7 @@ export default function AppBarActions() {
     setAnchorEl(null);
     auth.signinRedirect({
       redirect_uri: `${OidcConfig.redirect_uri}${window.location.search}`,
+      prompt: "login",
     });
   };
 

--- a/centre-web/src/routes/logout.tsx
+++ b/centre-web/src/routes/logout.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/logout")({
 });
 
 function Logout() {
-  const { signoutSilent, removeUser, isAuthenticated } = useAuth();
+  const { signoutSilent, isAuthenticated } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -19,7 +19,7 @@ function Logout() {
     };
 
     void handleLogout();
-  }, [navigate, removeUser, signoutSilent]);
+  }, [navigate, signoutSilent]);
 
   useEffect(() => {
     if (!isAuthenticated) {

--- a/centre-web/src/routes/logout.tsx
+++ b/centre-web/src/routes/logout.tsx
@@ -7,21 +7,28 @@ export const Route = createFileRoute("/logout")({
 });
 
 function Logout() {
-  const { signoutSilent, isAuthenticated } = useAuth();
-
+  const { signoutSilent, removeUser, isAuthenticated } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
-    signoutSilent();
-  }, [signoutSilent]);
+    const handleLogout = async () => {
+      try {
+        await signoutSilent();
+      } catch {
+        await removeUser();
+      } finally {
+        navigate({ to: "/", replace: true });
+      }
+    };
+
+    void handleLogout();
+  }, [navigate, removeUser, signoutSilent]);
 
   useEffect(() => {
     if (!isAuthenticated) {
-      navigate({
-        to: "/",
-      });
+      navigate({ to: "/", replace: true });
     }
   }, [isAuthenticated, navigate]);
 
-  return <p>...Loading</p>;
+  return null;
 }

--- a/centre-web/src/routes/logout.tsx
+++ b/centre-web/src/routes/logout.tsx
@@ -12,13 +12,10 @@ function Logout() {
 
   useEffect(() => {
     const handleLogout = async () => {
-      try {
+
         await signoutSilent();
-      } catch {
-        await removeUser();
-      } finally {
         navigate({ to: "/", replace: true });
-      }
+      
     };
 
     void handleLogout();

--- a/centre-web/src/routes/oidc-callback.tsx
+++ b/centre-web/src/routes/oidc-callback.tsx
@@ -18,7 +18,7 @@ function OidcCallback() {
   }
 
   if (!isLoading && isAuthenticated) {
-    return <Navigate to="/launchpad" />;
+    return <Navigate to="/launchpad/" />;
   }
 
   return <PageLoader />;


### PR DESCRIPTION
Description :
Silent logout redirects the user to home once the OIDC session clears, and Login now always prompts for credentials instead of silently reusing SSO.

Changes Included :
- Ensure /logout clears the local OIDC session immediately, attempts a silent signout, and routes home once the user is unauthenticated—preventing the app from getting stuck on the Keycloak end-session screen.
- Force signinRedirect to include prompt: "login" so Keycloak always presents the credential form instead of silently reusing an SSO session.
- Adjust the login callback to land on /launchpad/, eliminating the post-login 404.
- Update the app bar logo behavior so it sends authenticated users to /launchpad/ and everyone else to /, aligning navigation with session state.