### PR TITLE
CENTR-73: Hide Description is not working on the document search

### DIFF
--- a/centre-web/src/components/DocumentSearch/Header.tsx
+++ b/centre-web/src/components/DocumentSearch/Header.tsx
@@ -1,11 +1,14 @@
 import { Box, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
+import { useLaunchpadStore } from "@/stores/launchpadStore";
 
 export const Header = () => {
+  const { showDescription } = useLaunchpadStore();
+
   return (
     <Box
       sx={{
-        height: "81px",
+        height: showDescription ? "81px" : "50px",
         backgroundColor: BCDesignTokens.surfaceColorBackgroundLightBlue,
       }}
     >
@@ -31,9 +34,11 @@ export const Header = () => {
             Document Search
           </Typography>
         </Box>
-        <Typography variant="body2" width="100%">
-          Search all the documents in EPIC
-        </Typography>
+        {showDescription && (
+          <Typography variant="body2" width="100%">
+            Search all the documents in EPIC
+          </Typography>
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Description:
Hide the description text in Document Search header when "View Description" is toggled off, matching the behavior of other app tiles on the launchpad.

Changes Included :

- Updated DocumentSearch/Header.tsx to use the showDescription state from useLaunchpadStore
- Conditionally render the description text "Search all the documents in EPIC" based on the toggle state