### PR TITLE
CENTR-74:Cards should be displayed in rows of 3 max, even when the screen is wider

### DIFF
--- a/centre-web/src/components/LaunchAppTile/List.tsx
+++ b/centre-web/src/components/LaunchAppTile/List.tsx
@@ -116,9 +116,9 @@ export const List = ({ items }: ListProps) => {
       onDragEnd={handleDragEnd}
     >
       <SortableContext items={sortedItems} strategy={rectSortingStrategy}>
-        <Grid container rowSpacing={4} spacing={2} direction={"row"}>
+        <Grid container rowSpacing={4} spacing={2} direction={"row"} sx={{ maxWidth: "1090px" }}>
           {sortedItems.map((item) => (
-            <Grid item key={item.id}>
+            <Grid item xs={12} sm={6} md={4} key={item.id}>
               <SortableItem item={item} />
             </Grid>
           ))}

--- a/centre-web/src/components/RequestAccessTile/List.tsx
+++ b/centre-web/src/components/RequestAccessTile/List.tsx
@@ -7,9 +7,9 @@ type ListProps = {
 };
 export const List = ({ items }: ListProps) => {
   return (
-    <Grid container spacing={2} direction={"row"}>
+    <Grid container  rowSpacing={4} spacing={2} direction={"row"} sx={{ maxWidth: '1100px' }}>
       {items.map((item) => (
-        <Grid item key={item.id}>
+        <Grid item xs={12} sm={6} md={4} lg={4} key={item.id}>
           <RequestAccessTile data={item} />
         </Grid>
       ))}


### PR DESCRIPTION
Summary
Updates the List to show 3 cards per row on larger screens and limits the container width.

Changes
- Layout update
- Shows 3 cards per row on desktop/tablet screens
- Shows 2 cards per row on smaller tablets
- Shows 1 card per row on mobile
- Prevents the grid from stretching too wide on large screens