### PR TITLE
CENTRE-task#82: Refines app user access revocation

### DIFF
--- a/centre-api/src/centre_api/services/auth_api_service.py
+++ b/centre-api/src/centre_api/services/auth_api_service.py
@@ -176,6 +176,36 @@ class AuthApiService:
             raise error
 
     @staticmethod
+    def delete_user_group(username: str, group_name: str, del_sub_group_mappings: bool = True):
+        """Delete user from a specific group and optionally its subgroups.
+
+        Args:
+            username: The Keycloak username
+            group_name: The parent group name (e.g., 'TRACK', 'COMPLIANCE')
+            del_sub_group_mappings: If True, removes from all subgroups too
+
+        Returns:
+            Response from auth-api
+        """
+        try:
+            query_params = urlencode({'del_sub_group_mappings': str(del_sub_group_mappings).lower()})
+            base_url = f'{os.getenv("AUTH_API")}/api/users/{username}/groups/{group_name}?{query_params}'
+
+            headers = {
+                'Content-Type': 'application/json',
+                'Authorization': g.authorization_header,
+            }
+
+            timeout = current_app.config.get('CONNECT_TIMEOUT', 30)
+            response = requests.delete(base_url, headers=headers, timeout=timeout)
+            response.raise_for_status()
+
+            return response
+        except requests.RequestException as error:
+            current_app.logger.error(f'Error deleting user group mapping for {username}/{group_name}: {error}')
+            raise error
+
+    @staticmethod
     def patch_user(username: str, patch_data: dict):
         """Patch a user's information in the Auth API.
 

--- a/centre-api/src/centre_api/services/user_service.py
+++ b/centre-api/src/centre_api/services/user_service.py
@@ -15,7 +15,12 @@
 from collections import defaultdict
 
 from centre_api.enums.access_request_status import AccessRequestsStatusEnum
-from centre_api.enums.epic_app import APP_NAME_TO_CLIENT_NAME_MAP, GROUP_TO_APP_NAME_MAP, EpicAppClientName
+from centre_api.enums.epic_app import (
+    APP_NAME_TO_CLIENT_NAME_MAP,
+    APP_NAME_TO_GROUP_MAP,
+    GROUP_TO_APP_NAME_MAP,
+    EpicAppClientName
+)
 from centre_api.models.access_requests import AccessRequests as AccessRequestsModal
 from centre_api.services.auth_api_service import AuthApiService
 from centre_api.utils.token_info import TokenInfo
@@ -102,13 +107,28 @@ class UserService:
 
     @classmethod
     def revoke_user_access(cls, username: str, access_data: dict):
-        """Update user group."""
-        had_admin_access_on_app = cls.has_admin_access_on_app(access_data.get('app_name'))
+        """Revoke user access from a specific app."""
+        app_name = access_data.get('app_name')
+
+        # Check permissions
+        had_admin_access_on_app = cls.has_admin_access_on_app(app_name)
         if not had_admin_access_on_app:
             raise PermissionError(f'User does not have permission to update access for app'
-                                  f' "{access_data.get("app_name")}".')
+                                  f' "{app_name}".')
 
-        response = AuthApiService.delete_all_user_group_mapping(username)
+        # Map app_name to group_name using existing mapping
+        # e.g., 'epic_track' -> 'TRACK'
+        group_name = APP_NAME_TO_GROUP_MAP.get(app_name)
+
+        if not group_name:
+            raise ValueError(f'Invalid app_name: {app_name}')
+
+        # Delete from app-specific parent group + all subgroups
+        response = AuthApiService.delete_user_group(
+            username,
+            group_name,
+            del_sub_group_mappings=True
+        )
 
         return response
 

--- a/centre-api/src/centre_api/services/user_service.py
+++ b/centre-api/src/centre_api/services/user_service.py
@@ -16,11 +16,7 @@ from collections import defaultdict
 
 from centre_api.enums.access_request_status import AccessRequestsStatusEnum
 from centre_api.enums.epic_app import (
-    APP_NAME_TO_CLIENT_NAME_MAP,
-    APP_NAME_TO_GROUP_MAP,
-    GROUP_TO_APP_NAME_MAP,
-    EpicAppClientName
-)
+    APP_NAME_TO_CLIENT_NAME_MAP, APP_NAME_TO_GROUP_MAP, GROUP_TO_APP_NAME_MAP, EpicAppClientName)
 from centre_api.models.access_requests import AccessRequests as AccessRequestsModal
 from centre_api.services.auth_api_service import AuthApiService
 from centre_api.utils.token_info import TokenInfo


### PR DESCRIPTION
Introduces a dedicated service method to delete a user from a specific group and its subgroups in the Auth API.

Updates the user access revocation process to leverage this new method. This ensures that when access to an application is revoked, the user is accurately removed from the corresponding primary group and all associated subgroups based on the application name, enhancing the granularity and accuracy of user access management.