### PR TITLE
CENTR-84:Role Edit popup does not display the user’s currently assigned roles.

### DIFF
--- a/centre-web/src/components/AuthManagement/EditAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/EditAccess/index.tsx
@@ -58,11 +58,9 @@ export const EditAccessModal = ({
     if (accessLevelsLoading || accessLevels.length === 0 || !app.group_path) {
       return;
     }
-    const normalizePath = (path: string) => path.replace(/^\/+/, '');
-    const normalizedAppPath = normalizePath(app.group_path);
     
     const matchingLevel = accessLevels.find(
-      (level) => normalizePath(level.group_path) === normalizedAppPath,
+      (level) => level.group_path.includes(app.group_path!),
     );
     
     if (matchingLevel) {

--- a/centre-web/src/components/AuthManagement/EditAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/EditAccess/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useGeteApplicationAccessLevels } from "@/hooks/api/useApplications";
 import { CentreUser, CentreUserApp } from "@/models/CentreUser";
 import { useModal } from "@/components/Shared/Modals/modalStore";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { modalStyle } from "@/components/Shared/Modals/constants";
 import { getAppChipTitle } from "../utils";
 import { Unless, When } from "react-if";
@@ -47,14 +47,28 @@ export const EditAccessModal = ({
   });
 
   const { setClose } = useModal();
-  const [selectedRole, setSelectedRole] = useState<string | null>(
-    app.group_path ?? null,
-  );
-
+  
   const { data: accessLevels = [], isLoading: accessLevelsLoading } =
     useGeteApplicationAccessLevels({
       appName: app.name,
     });
+
+  const [selectedRole, setSelectedRole] = useState<string | null>(null);
+  useEffect(() => {
+    if (accessLevelsLoading || accessLevels.length === 0 || !app.group_path) {
+      return;
+    }
+    const normalizePath = (path: string) => path.replace(/^\/+/, '');
+    const normalizedAppPath = normalizePath(app.group_path);
+    
+    const matchingLevel = accessLevels.find(
+      (level) => normalizePath(level.group_path) === normalizedAppPath,
+    );
+    
+    if (matchingLevel) {
+      setSelectedRole(matchingLevel.group_path);
+    }
+  }, [app.group_path, accessLevels, accessLevelsLoading]);
 
   const handleClose = () => {
     setClose();


### PR DESCRIPTION
Summary:
Fixes an issue where the current access level wasn't pre-selected when editing a user's access in the Edit Access modal.

Solution:
The component now finds and pre-selects the user's current access level when the modal opens, so the correct option is highlighted.