### PR TITLE
CENTRE-task#83: Adds CENTRE group mapping

### DIFF
--- a/centre-web/src/models/KCGroup.ts
+++ b/centre-web/src/models/KCGroup.ts
@@ -16,6 +16,7 @@ export const enum EpicGroups {
   TRACK = "TRACK",
   ENGAGE = "ENGAGE",
   PUBLIC = "PUBLIC",
+  CENTRE = "CENTRE",
 }
 
 export const EPIC_APP_TO_GROUP = {
@@ -25,6 +26,7 @@ export const EPIC_APP_TO_GROUP = {
   [EpicAppName.EPIC_TRACK]: EpicGroups.TRACK,
   [EpicAppName.EPIC_ENGAGE]: EpicGroups.ENGAGE,
   [EpicAppName.EPIC_PUBLIC]: EpicGroups.PUBLIC,
+  [EpicAppName.EPIC_CENTRE]: EpicGroups.CENTRE,
 };
 
 const RAW_EPIC_GROUPS = {

--- a/centre-web/src/utils/constants.ts
+++ b/centre-web/src/utils/constants.ts
@@ -7,7 +7,7 @@
 export const EPIC_ADMIN_ROLES: Record<string, string[]> = {
   "epic-centre": ["manage_auth", "manage_users"],
   "epictrack-web": ["manage_users"],
-  "epic-engage": ["manage_users"],
+  "epic-engage": ["create_admin_user"],
   "epic-compliance": ["super_user"],
   "epic-condition": [""],
   "epic-submit": ["extended_eao_edit"],


### PR DESCRIPTION
Adds support for the CENTRE epic application. This update defines the `CENTRE` group within the `EpicGroups` enumeration and establishes its mapping, enabling proper categorization and integration into the application's group management system.

Relates to #83