### PR TITLE
CENTRE-77 Filters access requests by admin permissions

### DIFF
--- a/centre-api/src/centre_api/services/access_requests.py
+++ b/centre-api/src/centre_api/services/access_requests.py
@@ -11,8 +11,11 @@ class AccessRequestsService:
     @classmethod
     def get_all(cls, args):
         """Return all access requests by status, enriched with user details."""
+        current_user = AuthApiService.get_user_by_username(TokenInfo.get_username())
+        administrated_apps = set(AuthApiService.get_administered_apps(current_user))
         access_requests = AccessRequestsModal.get_all(args)
-        serialized_requests = [req.to_dict() for req in access_requests]
+        filtered_requests = [req for req in access_requests if req.app.name in administrated_apps]
+        serialized_requests = [req.to_dict() for req in filtered_requests]
         enriched_requests = cls._enrich_with_user_details(serialized_requests)
         return enriched_requests
 

--- a/centre-api/src/centre_api/services/auth_api_service.py
+++ b/centre-api/src/centre_api/services/auth_api_service.py
@@ -18,7 +18,7 @@ from urllib.parse import urlencode
 import requests
 from flask import current_app, g
 
-from centre_api.enums.epic_app import EPIC_CLIENT_TO__ADMIN_GROUPS_PATHS
+from centre_api.enums.epic_app import EPIC_CLIENT_TO__ADMIN_GROUPS_PATHS, CLIENT_NAME_TO_APP_NAME_MAP
 
 
 class AuthApiService:
@@ -250,3 +250,13 @@ class AuthApiService:
             return False
         groups = user.get('groups', [])
         return any(group.get('path') == admin_group_path for group in groups)
+
+    @staticmethod
+    def get_administered_apps(user):
+        """Get a list of applications the user has admin privileges for."""
+        administered_apps = []
+        groups = user.get('groups', [])
+        for client_name, admin_group_path in EPIC_CLIENT_TO__ADMIN_GROUPS_PATHS.items():
+            if any(group.get('path') == admin_group_path for group in groups):
+                administered_apps.append(CLIENT_NAME_TO_APP_NAME_MAP.get(client_name))
+        return administered_apps

--- a/centre-api/src/centre_api/services/auth_api_service.py
+++ b/centre-api/src/centre_api/services/auth_api_service.py
@@ -18,7 +18,7 @@ from urllib.parse import urlencode
 import requests
 from flask import current_app, g
 
-from centre_api.enums.epic_app import EPIC_CLIENT_TO__ADMIN_GROUPS_PATHS, CLIENT_NAME_TO_APP_NAME_MAP
+from centre_api.enums.epic_app import CLIENT_NAME_TO_APP_NAME_MAP, EPIC_CLIENT_TO__ADMIN_GROUPS_PATHS
 
 
 class AuthApiService:

--- a/centre-web/src/components/AuthManagement/EditAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/EditAccess/index.tsx
@@ -46,7 +46,7 @@ export const EditAccessModal = ({
   });
 
   const { setClose } = useModal();
-  
+
   const { data: accessLevels = [], isLoading: accessLevelsLoading } =
     useGeteApplicationAccessLevels({
       appName: app.name,
@@ -57,11 +57,11 @@ export const EditAccessModal = ({
     if (accessLevelsLoading || accessLevels.length === 0 || !app.group_path) {
       return;
     }
-    
-    const matchingLevel = accessLevels.find(
-      (level) => level.group_path.includes(app.group_path!),
+
+    const matchingLevel = accessLevels.find((level) =>
+      level.group_path.includes(app.group_path!),
     );
-    
+
     if (matchingLevel) {
       setSelectedRole(matchingLevel.group_path);
     }

--- a/centre-web/src/contexts/UserContext.tsx
+++ b/centre-web/src/contexts/UserContext.tsx
@@ -41,7 +41,6 @@ export const UserProvider = ({ children }: UserProviderProps) => {
   // Get username from JWT token
   const username = auth.user?.profile.preferred_username as string | undefined;
 
-  // Fetch user data using the existing hook
   const {
     data: user,
     isLoading,
@@ -68,7 +67,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     (appName: EpicAppName) => {
       return checkIsAdminOfApp(user?.groups, appName);
     },
-    [user?.groups]
+    [user?.groups],
   );
 
   // Compute admin status for all apps

--- a/centre-web/src/hooks/api/useUsers.ts
+++ b/centre-web/src/hooks/api/useUsers.ts
@@ -39,7 +39,8 @@ export const useGetUser = (params: GetUserParams) => {
   const { username, ...rest } = params;
   return useQuery({
     queryKey: [QUERY_KEY.USER, username],
-    queryFn: () => getUser({ username, ...rest }),
+    queryFn: () => getUser({ username }),
+    ...rest,
   });
 };
 

--- a/centre-web/src/routes/_authenticated.tsx
+++ b/centre-web/src/routes/_authenticated.tsx
@@ -1,5 +1,6 @@
 import { PageLoader } from "@/components/PageLoader";
 import SideNavBar from "@/components/SideNav/SideNavBar";
+import { useCurrentUser } from "@/contexts/UserContext";
 import { OidcConfig } from "@/utils/config";
 import { Box } from "@mui/material";
 import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
@@ -23,8 +24,9 @@ export const Route = createFileRoute("/_authenticated")({
 
 function AuthenticatedRoute() {
   const { isAuthenticated, isLoading } = useAuth();
+  const { isLoading: userLoading } = useCurrentUser();
 
-  if (isLoading) {
+  if (isLoading || userLoading) {
     return <PageLoader />;
   }
 


### PR DESCRIPTION
Restricts the visibility of access requests, ensuring users can only view requests for applications they administer.

- Updates the `get_all` method in `AccessRequestsService` to first determine the current user's administered applications.
- Filters the retrieved access requests, returning only those associated with applications the user has administrative privileges for.
- Introduces a new helper method, `get_administered_apps`, in `AuthApiService`. This method identifies applications a user can administer based on their group memberships and a predefined mapping between client and application names.

This change enhances data security and access control by preventing users from viewing access requests for applications outside their administrative scope.

Relates to CENTRE-77