### PR TITLE
CENTR-94: Banner on Request Access Page: As a DST member, you can assign yourself access directly.

### DIFF
--- a/centre-web/src/routes/_authenticated/request-access/index.tsx
+++ b/centre-web/src/routes/_authenticated/request-access/index.tsx
@@ -2,7 +2,8 @@ import { PageLoader } from "@/components/PageLoader";
 import { List as RequestAccessTileList } from "@/components/RequestAccessTile/List";
 import { PageContainer } from "@/components/Shared/PageGrid";
 import { useGetRequestCatalogApplications } from "@/hooks/api/useApplications";
-import { Grid, Typography } from "@mui/material";
+import { useCurrentUser } from "@/contexts/UserContext";
+import { Box, Grid, Typography } from "@mui/material";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authenticated/request-access/")({
@@ -12,6 +13,7 @@ export const Route = createFileRoute("/_authenticated/request-access/")({
 function RequestAccess() {
   const { data: applications = [], isPending } =
     useGetRequestCatalogApplications();
+  const { isDstAdmin } = useCurrentUser();
 
   if (isPending) {
     return <PageLoader />;
@@ -36,6 +38,31 @@ function RequestAccess() {
             You will receive an email when your request has been processed.
           </Typography>
         </Grid>
+        {isDstAdmin && (
+          <Grid item xs={12} mt="32px">
+            <Box
+              sx={{
+                backgroundColor: "#FEF1D8",
+                border: "1px solid #F8BB47",
+                borderRadius: "4px",
+                padding: "8px",
+                maxWidth: "1060px",
+              }}
+            >
+              <Typography
+                variant="body1"
+                sx={{
+                  fontSize: "16px",
+                  fontStyle: "normal",
+                  fontWeight: 400,
+                  lineHeight: "27.008px",
+                }}
+              >
+                As a EPIC.auth Superuser, you can assign yourself Access Levels for all the EPIC applications from your EPIC.auth user profile.
+              </Typography>
+            </Box>
+          </Grid>
+        )}
         <Grid container item xs={12} mt="32px">
           <RequestAccessTileList items={applications} />
         </Grid>


### PR DESCRIPTION
Description:
Adds an informational banner on the Request Access page that appears only for EPIC.auth Superusers. The banner explains that Superusers can assign themselves Access Levels for all EPIC applications from their EPIC.auth user profile.

Changes Made:
- Added a new informational banner above the application tiles
- Banner only shows for users with EPIC.auth Superuser permissions