### PR TITLE
CENTR-95:Every link that is copied and pasted in the same browser but on different tab logs you out of .centre

### DIFF
--- a/centre-web/src/routes/_authenticated.tsx
+++ b/centre-web/src/routes/_authenticated.tsx
@@ -4,12 +4,18 @@ import { useCurrentUser } from "@/contexts/UserContext";
 import { OidcConfig } from "@/utils/config";
 import { Box } from "@mui/material";
 import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { useAuth } from "react-oidc-context";
 
 export const Route = createFileRoute("/_authenticated")({
-  beforeLoad: ({ context }) => {
-    const { isAuthenticated, signinRedirect, isLoading } =
-      context.authentication;
+  component: AuthenticatedRoute,
+});
+
+function AuthenticatedRoute() {
+  const { isAuthenticated, signinRedirect, isLoading } = useAuth();
+  const { isLoading: userLoading } = useCurrentUser();
+
+  useEffect(() => {
     if (!isAuthenticated && !isLoading) {
       signinRedirect({
         redirect_uri: window.location.href,
@@ -18,13 +24,7 @@ export const Route = createFileRoute("/_authenticated")({
         },
       });
     }
-  },
-  component: AuthenticatedRoute,
-});
-
-function AuthenticatedRoute() {
-  const { isAuthenticated, isLoading } = useAuth();
-  const { isLoading: userLoading } = useCurrentUser();
+  }, [isAuthenticated, isLoading, signinRedirect]);
 
   if (isLoading || userLoading) {
     return <PageLoader />;

--- a/centre-web/src/routes/oidc-callback.tsx
+++ b/centre-web/src/routes/oidc-callback.tsx
@@ -8,6 +8,7 @@ export const Route = createFileRoute("/oidc-callback")({
 
 function OidcCallback() {
   const { isAuthenticated, isLoading, error } = useAuth();
+  const path = new URLSearchParams(window.location.search).get("path");
 
   if (isLoading) {
     return <PageLoader />;
@@ -17,8 +18,8 @@ function OidcCallback() {
     return <Navigate to="/error" />;
   }
 
-  if (!isLoading && isAuthenticated) {
-    return <Navigate to="/launchpad/" />;
+  if (isAuthenticated) {
+    return <Navigate to={path || "/launchpad/"} />;
   }
 
   return <PageLoader />;


### PR DESCRIPTION

Summary:
Fixes authentication redirect to preserve the original URL path. Adds OIDC configuration options and optimizes authentication code.

Changes:
- Authentication URL preservation: Users are redirected back to their original destination after login instead of always going to /launchpad