### PR TITLE
CENTR-98:The cards stack up weirdly on smaller screen

### DIFF
--- a/centre-web/src/components/LaunchAppTile/BookmarkSection.tsx
+++ b/centre-web/src/components/LaunchAppTile/BookmarkSection.tsx
@@ -25,6 +25,10 @@ const AddBookmarkButton = (props: ButtonProps) => {
         padding: "12px 8px",
         color: BCDesignTokens.themePrimaryBlue,
         border: `2px solid ${BCDesignTokens.themePrimaryBlue}`,
+        minWidth: 0,
+        textTransform: "none",
+        whiteSpace: "nowrap",
+        flexShrink: 0,
       }}
     >
       Add/Edit Bookmarks
@@ -54,7 +58,18 @@ export const BookmarkSection = ({ epicApp }: BookmarkSectionProps) => {
         width="100%"
         padding="8px 0"
       >
-        <Typography variant="h6" fontWeight={400}>
+        <Typography 
+          variant="h6" 
+          fontWeight={400}
+          sx={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            minWidth: 0,
+            flex: 1,
+            marginRight: 1,
+          }}
+        >
           Bookmarks
         </Typography>
         <AddBookmarkButton color="secondary" onClick={handleAddEditBookmarks} />

--- a/centre-web/src/components/LaunchAppTile/Content.tsx
+++ b/centre-web/src/components/LaunchAppTile/Content.tsx
@@ -28,6 +28,9 @@ export const Content = ({ epicApp }: ContentProps) => {
           href={launch_url}
           target="_blank"
           rel="noopener noreferrer"
+          sx={{
+            textTransform: "none",
+          }}
         >
           Open in new tab
         </Button>
@@ -35,11 +38,12 @@ export const Content = ({ epicApp }: ContentProps) => {
         <Box
           sx={{
             padding: "8px 0 12px 0",
+            width: "100%",
           }}
         >
           <Divider
             sx={{
-              width: "320px",
+              width: "100%",
               backgroundColor: BCDesignTokens.themeGray50,
             }}
           />

--- a/centre-web/src/components/LaunchAppTile/Header.tsx
+++ b/centre-web/src/components/LaunchAppTile/Header.tsx
@@ -45,7 +45,17 @@ export const Header = ({
             width: "100%",
           }}
         >
-          <Typography variant="h4" component="div">
+          <Typography 
+            variant="h4" 
+            component="div"
+            sx={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
             {title}
           </Typography>
           <IconButton
@@ -69,7 +79,14 @@ export const Header = ({
           </IconButton>
         </Box>
         {showDescription && (
-          <Typography variant="body2" width="100%" title={description}>
+          <Typography 
+            variant="body2" 
+            sx={{ 
+              width: "100%", 
+              minWidth: 0,
+            }} 
+            title={description}
+          >
             <LinesEllipsis
               text={description}
               maxLine={2}

--- a/centre-web/src/components/LaunchAppTile/List.tsx
+++ b/centre-web/src/components/LaunchAppTile/List.tsx
@@ -1,5 +1,5 @@
 import { EpicApp } from "@/models/EpicApp";
-import { Grid } from "@mui/material";
+import { Box } from "@mui/material";
 import { LaunchAppTile } from ".";
 import {
   DndContext,
@@ -51,7 +51,12 @@ const SortableItem = ({ item }: SortableItemProps) => {
   return (
     <div
       ref={setNodeRef}
-      style={style}
+      style={{
+        ...style,
+        width: "100%",
+        maxWidth: "345px",
+        boxSizing: "border-box",
+      }}
       role="button"
       aria-grabbed={isDragging}
       aria-label={`Application card: ${item.title}`}
@@ -116,13 +121,39 @@ export const List = ({ items }: ListProps) => {
       onDragEnd={handleDragEnd}
     >
       <SortableContext items={sortedItems} strategy={rectSortingStrategy}>
-        <Grid container rowSpacing={4} spacing={2} direction={"row"} sx={{ maxWidth: "1090px" }}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(0, 345px))",
+            gap: "16px",
+            justifyContent: "center",
+            width: "100%",
+            maxWidth: "1090px",
+            boxSizing: "border-box",
+            padding: "0 16px",
+            "@media (max-width: 1080px)": {
+              gridTemplateColumns: "repeat(2, minmax(0, 345px))",
+            },
+            "@media (max-width: 720px)": {
+              gridTemplateColumns: "minmax(0, 345px)",
+            },
+          }}
+        >
           {sortedItems.map((item) => (
-            <Grid item xs={12} sm={6} md={4} key={item.id}>
+            <Box
+              key={item.id}
+              sx={{
+                display: "flex",
+                justifyContent: "center",
+                width: "100%",
+                maxWidth: "345px",
+                boxSizing: "border-box",
+              }}
+            >
               <SortableItem item={item} />
-            </Grid>
+            </Box>
           ))}
-        </Grid>
+        </Box>
       </SortableContext>
       <DragOverlay>
         {activeItem ? (

--- a/centre-web/src/components/LaunchAppTile/index.tsx
+++ b/centre-web/src/components/LaunchAppTile/index.tsx
@@ -17,11 +17,14 @@ export const LaunchAppTile = ({ item, dragListeners, dragAttributes }: LaunchApp
     <Paper
       elevation={2}
       sx={{
-        width: "345px",
+        width: "100%",
+        maxWidth: "345px",
         height: showDescription ? "386px" : "340px",
         boxShadow: BCDesignTokens.surfaceShadowMedium,
         display: "flex",
         flexDirection: "column",
+        overflow: "hidden",
+        boxSizing: "border-box",
       }}
     >
       <Header data={item} dragListeners={dragListeners} dragAttributes={dragAttributes} />


### PR DESCRIPTION
Summary:
Fixes layout issues with EPIC centre application cards by implementing a CSS Grid layout, ensuring proper card alignment, preventing overlapping, and improving responsive behavior.

Key Changes
- Implemented 3 cards per row on desktop
- Added responsive breakpoints (3 → 2 → 1 cards per row based on screen size)
- Implemented text truncation with ellipsis for long titles/descriptions
- Ensured buttons resize properly within card boundaries