### PR TITLE
Refines UI layout and component styling for consistency

### DIFF
--- a/centre-web/src/components/DocumentSearch/Header.tsx
+++ b/centre-web/src/components/DocumentSearch/Header.tsx
@@ -19,7 +19,6 @@ export const Header = () => {
           flexDirection: "column",
           alignItems: "flex-start",
           justifyContent: "flex-start",
-          gap: "8px",
         }}
       >
         <Box
@@ -30,9 +29,7 @@ export const Header = () => {
             width: "100%",
           }}
         >
-          <Typography variant="h6" component="div">
-            Document Search
-          </Typography>
+          <Typography variant="h4">Document Search</Typography>
         </Box>
         {showDescription && (
           <Typography variant="body2" width="100%">

--- a/centre-web/src/components/LaunchAppTile/AccessLogSection.tsx
+++ b/centre-web/src/components/LaunchAppTile/AccessLogSection.tsx
@@ -18,12 +18,20 @@ export const AccessLogSection = ({ user }: AccessLogSectionProps) => {
         gap: "8px",
       }}
     >
-      <LabeledItem label="Access Level">
-        <Box sx={{ flex: 1, display: "flex", justifyContent: "center" }}>
-          <Typography variant="body2">{user.access_level ?? ""}</Typography>
-        </Box>
+      <LabeledItem
+        label="Access Level"
+        labelProps={{
+          sx: { width: "95px" },
+        }}
+      >
+        <Typography variant="body2">{user.access_level ?? ""}</Typography>
       </LabeledItem>
-      <LabeledItem label="Last Accessed">
+      <LabeledItem
+        label="Last Accessed"
+        labelProps={{
+          sx: { width: "95px" },
+        }}
+      >
         <Typography variant="body2">{user.last_accessed ?? ""}</Typography>
       </LabeledItem>
     </Box>

--- a/centre-web/src/components/LaunchAppTile/BookmarkSection.tsx
+++ b/centre-web/src/components/LaunchAppTile/BookmarkSection.tsx
@@ -1,38 +1,23 @@
 import { EpicApp } from "@/models/EpicApp";
-import {
-  Box,
-  Button,
-  ButtonProps,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { Box, Stack, Tooltip, Typography } from "@mui/material";
 import { Circle } from "@mui/icons-material";
 import { CentreLink } from "../Shared/CentreLink";
 import { useModal } from "../Shared/Modals/modalStore";
 import { AddBookmark } from "./AddBookmark";
-import { BCDesignTokens } from "epic.theme";
+import { CentreLinkProps } from "../Shared/CentreLink/type";
 
-const AddBookmarkButton = (props: ButtonProps) => {
+const AddBookmarkButton = (props: CentreLinkProps) => {
   const { sx, ...otherProps } = props;
   return (
-    <Button
+    <CentreLink
       {...otherProps}
       sx={{
         ...(sx ?? {}),
-        height: "32px",
         fontSize: "12px",
-        padding: "12px 8px",
-        color: BCDesignTokens.themePrimaryBlue,
-        border: `2px solid ${BCDesignTokens.themePrimaryBlue}`,
-        minWidth: 0,
-        textTransform: "none",
-        whiteSpace: "nowrap",
-        flexShrink: 0,
       }}
     >
       Add/Edit Bookmarks
-    </Button>
+    </CentreLink>
   );
 };
 
@@ -50,16 +35,15 @@ export const BookmarkSection = ({ epicApp }: BookmarkSectionProps) => {
   const bookmarks = epicApp?.user?.bookmarks || [];
 
   return (
-    <Box sx={{ width: "100%" }}>
+    <Box id="bookmark-section" sx={{ width: "100%", padding: "12px 0 0 0" }}>
       <Stack
         direction={"row"}
         justifyContent={"space-between"}
         alignItems={"center"}
         width="100%"
-        padding="8px 0"
       >
-        <Typography 
-          variant="h6" 
+        <Typography
+          variant="h6"
           fontWeight={400}
           sx={{
             overflow: "hidden",

--- a/centre-web/src/components/LaunchAppTile/Content.tsx
+++ b/centre-web/src/components/LaunchAppTile/Content.tsx
@@ -49,7 +49,7 @@ export const Content = ({ epicApp }: ContentProps) => {
           />
         </Box>
         {!is_public && (
-          <Box sx={{ width: "100%", marginTop: "auto" }}>
+          <Box sx={{ width: "100%" }}>
             <AccessLogSection user={epicApp.user} />
           </Box>
         )}

--- a/centre-web/src/components/LaunchAppTile/Header.tsx
+++ b/centre-web/src/components/LaunchAppTile/Header.tsx
@@ -23,7 +23,7 @@ export const Header = ({
   return (
     <Box
       sx={{
-        height: showDescription ? "100px" : "50px",
+        height: showDescription ? "90px" : "50px",
         backgroundColor: BCDesignTokens.surfaceColorBackgroundLightBlue,
       }}
     >
@@ -34,7 +34,6 @@ export const Header = ({
           flexDirection: "column",
           alignItems: "flex-start",
           justifyContent: "flex-start",
-          gap: "8px",
         }}
       >
         <Box
@@ -45,8 +44,8 @@ export const Header = ({
             width: "100%",
           }}
         >
-          <Typography 
-            variant="h4" 
+          <Typography
+            variant="h4"
             component="div"
             sx={{
               overflow: "hidden",
@@ -79,12 +78,12 @@ export const Header = ({
           </IconButton>
         </Box>
         {showDescription && (
-          <Typography 
-            variant="body2" 
-            sx={{ 
-              width: "100%", 
+          <Typography
+            variant="body2"
+            sx={{
+              width: "100%",
               minWidth: 0,
-            }} 
+            }}
             title={description}
           >
             <LinesEllipsis

--- a/centre-web/src/components/LaunchAppTile/List.tsx
+++ b/centre-web/src/components/LaunchAppTile/List.tsx
@@ -126,11 +126,9 @@ export const List = ({ items }: ListProps) => {
             display: "grid",
             gridTemplateColumns: "repeat(3, minmax(0, 345px))",
             gap: "16px",
-            justifyContent: "center",
             width: "100%",
             maxWidth: "1090px",
             boxSizing: "border-box",
-            padding: "0 16px",
             "@media (max-width: 1080px)": {
               gridTemplateColumns: "repeat(2, minmax(0, 345px))",
             },

--- a/centre-web/src/components/LaunchAppTile/index.tsx
+++ b/centre-web/src/components/LaunchAppTile/index.tsx
@@ -10,16 +10,20 @@ type LaunchAppTileProps = {
   dragListeners?: any;
   dragAttributes?: any;
 };
-export const LaunchAppTile = ({ item, dragListeners, dragAttributes }: LaunchAppTileProps) => {
+export const LaunchAppTile = ({
+  item,
+  dragListeners,
+  dragAttributes,
+}: LaunchAppTileProps) => {
   const { showDescription } = useLaunchpadStore();
-  
+
   return (
     <Paper
       elevation={2}
       sx={{
         width: "100%",
         maxWidth: "345px",
-        height: showDescription ? "386px" : "340px",
+        height: showDescription ? "369px" : "329px",
         boxShadow: BCDesignTokens.surfaceShadowMedium,
         display: "flex",
         flexDirection: "column",
@@ -27,7 +31,11 @@ export const LaunchAppTile = ({ item, dragListeners, dragAttributes }: LaunchApp
         boxSizing: "border-box",
       }}
     >
-      <Header data={item} dragListeners={dragListeners} dragAttributes={dragAttributes} />
+      <Header
+        data={item}
+        dragListeners={dragListeners}
+        dragAttributes={dragAttributes}
+      />
       <Content epicApp={item} />
     </Paper>
   );

--- a/centre-web/src/components/RequestAccessTile/Header.tsx
+++ b/centre-web/src/components/RequestAccessTile/Header.tsx
@@ -1,3 +1,4 @@
+import { useLaunchpadStore } from "@/stores/launchpadStore";
 import { Box, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import LinesEllipsis from "react-lines-ellipsis";
@@ -10,10 +11,11 @@ type HeaderProps = {
 };
 export const Header = ({ data }: HeaderProps) => {
   const { title, description } = data;
+  const { showDescription } = useLaunchpadStore();
   return (
     <Box
       sx={{
-        height: "100px",
+        height: showDescription ? "90px" : "50px",
         backgroundColor: BCDesignTokens.surfaceColorBackgroundLightBlue,
       }}
     >
@@ -24,7 +26,6 @@ export const Header = ({ data }: HeaderProps) => {
           flexDirection: "column",
           alignItems: "flex-start",
           justifyContent: "flex-start",
-          gap: "8px",
         }}
       >
         <Box
@@ -35,19 +36,19 @@ export const Header = ({ data }: HeaderProps) => {
             width: "100%",
           }}
         >
-          <Typography variant="h6" component="div">
-            {title}
-          </Typography>
+          <Typography variant="h4">{title}</Typography>
         </Box>
-        <Typography variant="body2" width="100%">
-          <LinesEllipsis
-            text={description}
-            maxLine={2}
-            ellipsis="..."
-            trimRight
-            basedOn="letters"
-          />
-        </Typography>
+        {showDescription && (
+          <Typography variant="body2" width="100%">
+            <LinesEllipsis
+              text={description}
+              maxLine={2}
+              ellipsis="..."
+              trimRight
+              basedOn="letters"
+            />
+          </Typography>
+        )}
       </Box>
     </Box>
   );

--- a/centre-web/src/components/Shared/CentreLink/index.tsx
+++ b/centre-web/src/components/Shared/CentreLink/index.tsx
@@ -1,9 +1,6 @@
-import { LinkProps, Link as MuiLink } from "@mui/material";
+import { Link as MuiLink } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
-
-type CentreLinkProps = {
-  disabled?: boolean;
-} & LinkProps;
+import { CentreLinkProps } from "./type";
 
 export const CentreLink = (props: CentreLinkProps) => {
   const { children, disabled, sx, onClick, ...rest } = props;
@@ -18,7 +15,7 @@ export const CentreLink = (props: CentreLinkProps) => {
       sx={{
         color: BCDesignTokens.themeBlue90,
         textDecoration: "none",
-        cursor: onClick ? "pointer" : "inherit",
+        cursor: "pointer",
         "&:hover": {
           textDecoration: "underline",
         },

--- a/centre-web/src/components/Shared/CentreLink/type.ts
+++ b/centre-web/src/components/Shared/CentreLink/type.ts
@@ -1,0 +1,5 @@
+import { LinkProps } from "@mui/material";
+
+export type CentreLinkProps = {
+  disabled?: boolean;
+} & LinkProps;

--- a/centre-web/src/components/Shared/LabeledItem.tsx
+++ b/centre-web/src/components/Shared/LabeledItem.tsx
@@ -18,8 +18,8 @@ export const LabeledItem = ({
     <Stack
       direction="row"
       alignItems="center"
-      justifyContent={"space-between"}
-      spacing={2}
+      justifyContent={"flex-start"}
+      spacing={1}
     >
       <Typography
         variant="body2"


### PR DESCRIPTION
- The padding in the bookmark section has changed. Please adjust back to about 12px above and below the bookmark section.
- The card header section still needs reduced padding of 12px between header and description and description and bottom of the card. This applies to Launchpad and Request Access.
- Card header should be H4 and bookmark h6. (We can discuss and test together)
- Minimize the space between the Access level and Last Accessed labels and the role/last accessed date.
- Make the Add/Edit Bookmark button a link only, same font size as on the button, add an “Edit Icon” in front of the text.