### PR TITLE
CENTR-100:Adjust the columns on the table on smaller screens

### DIFF
--- a/centre-web/src/components/AuthManagement/UserAccess/CurrentAccessLevel/CurrentAccessTable.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/CurrentAccessLevel/CurrentAccessTable.tsx
@@ -80,16 +80,52 @@ export const CurrentAccessTable = ({ user }: CurrentAccessTableProps) => {
       <Table>
         <CentreTableHead>
           <TableRow>
-            <CentreTableHeadCell sx={{ width: "35%" }}>
+            <CentreTableHeadCell
+              sx={{
+                width: {
+                  xs: "28%",
+                  sm: "30%",
+                  md: "20%",
+                  lg: "25%",
+                },
+              }}
+            >
               Application
             </CentreTableHeadCell>
-            <CentreTableHeadCell sx={{ width: "35%" }}>
+            <CentreTableHeadCell
+              sx={{
+                width: {
+                  xs: "28%",
+                  sm: "30%",
+                  md: "20%",
+                  lg: "25%",
+                },
+              }}
+            >
               Current Access Level
             </CentreTableHeadCell>
-            <CentreTableHeadCell sx={{ width: "10%" }}>
+            <CentreTableHeadCell
+              sx={{
+                width: {
+                  xs: "22%",
+                  sm: "20%",
+                  md: "20%",
+                  lg: "20%",
+                },
+              }}
+            >
               Actions
             </CentreTableHeadCell>
-            <CentreTableHeadCell sx={{ width: "20%" }}></CentreTableHeadCell>
+            <CentreTableHeadCell
+              sx={{
+                width: {
+                  xs: "22%",
+                  sm: "20%",
+                  md: "40%",
+                  lg: "30%",
+                },
+              }}
+            ></CentreTableHeadCell>
           </TableRow>
         </CentreTableHead>
         <TableBody>

--- a/centre-web/src/components/AuthManagement/UserAccess/NewAccessRequests/NewRequestsTable.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/NewAccessRequests/NewRequestsTable.tsx
@@ -74,16 +74,52 @@ export const NewRequestsTable = ({
       <Table>
         <CentreTableHead>
           <TableRow>
-            <CentreTableHeadCell sx={{ width: "35%" }}>
+            <CentreTableHeadCell
+              sx={{
+                width: {
+                  xs: "28%",
+                  sm: "30%",
+                  md: "20%",
+                  lg: "25%",
+                },
+              }}
+            >
               Application
             </CentreTableHeadCell>
-            <CentreTableHeadCell sx={{ width: "35%" }}>
+            <CentreTableHeadCell
+              sx={{
+                width: {
+                  xs: "28%",
+                  sm: "30%",
+                  md: "20%",
+                  lg: "25%",
+                },
+              }}
+            >
               Current Access Level
             </CentreTableHeadCell>
-            <CentreTableHeadCell sx={{ width: "10%" }}>
+            <CentreTableHeadCell
+              sx={{
+                width: {
+                  xs: "22%",
+                  sm: "20%",
+                  md: "20%",
+                  lg: "20%",
+                },
+              }}
+            >
               Actions
             </CentreTableHeadCell>
-            <CentreTableHeadCell sx={{ width: "20%" }}></CentreTableHeadCell>
+            <CentreTableHeadCell
+              sx={{
+                width: {
+                  xs: "22%",
+                  sm: "20%",
+                  md: "40%",
+                  lg: "30%",
+                },
+              }}
+            ></CentreTableHeadCell>
           </TableRow>
         </CentreTableHead>
         <TableBody>


### PR DESCRIPTION
Summary:
In tables on the user details page, when the table is resized, the links wrap on two lines. We should adjust column resizing so the application and current access level resize first

Changes:
-Adjusted the table column width for different device sizes