### PR TITLE
CENTR-101: EPIC.auth - Display IDIR associated with user

### DIFF
--- a/centre-api/src/centre_api/schemas/user.py
+++ b/centre-api/src/centre_api/schemas/user.py
@@ -18,3 +18,4 @@ class UserSchema(Schema):
     enabled = fields.Bool()
     groups = fields.List(fields.Dict())
     attributes = fields.Dict()
+    

--- a/centre-api/src/centre_api/schemas/user.py
+++ b/centre-api/src/centre_api/schemas/user.py
@@ -17,3 +17,4 @@ class UserSchema(Schema):
     apps = fields.List(fields.Dict())
     enabled = fields.Bool()
     groups = fields.List(fields.Dict())
+    attributes = fields.Dict()

--- a/centre-api/src/centre_api/schemas/user.py
+++ b/centre-api/src/centre_api/schemas/user.py
@@ -18,4 +18,3 @@ class UserSchema(Schema):
     enabled = fields.Bool()
     groups = fields.List(fields.Dict())
     attributes = fields.Dict()
-    

--- a/centre-web/src/components/AuthManagement/UserAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/index.tsx
@@ -76,6 +76,14 @@ export const UserAccess = () => {
               <Typography variant="h4" gutterBottom>
                 {user?.last_name ?? ""}, {user?.first_name ?? ""}
               </Typography>
+              <Typography variant="h6" gutterBottom>
+                {user?.email ?? ""}
+                {user?.attributes?.idir_username?.[0] && (
+                  <span style={{ marginLeft: "8px", color: "#99A6B4" }}>
+                    ({user.attributes.idir_username[0]})
+                  </span>
+                )}
+              </Typography>
             </BarTitle>
           </Grid>
           <Grid item>

--- a/centre-web/src/models/CentreUser.ts
+++ b/centre-web/src/models/CentreUser.ts
@@ -16,4 +16,7 @@ export type CentreUser = {
   apps: CentreUserApp[];
   enabled: boolean;
   groups: KCGroup[];
+  attributes?: {
+    idir_username?: string[];
+  };
 };


### PR DESCRIPTION
### Summary
This update builds on the recent addition of email addresses to the user access management page by now also displaying each user's IDIR username alongside their email. This helps administrators quickly identify users by their government IDIR credentials.

### What Changed
- The system now properly sends user identification information (IDIR username) from the backend to the frontend
- The user access page now displays the IDIR username in parentheses next to the user's email address
- The IDIR username appears in a subtle gray color to distinguish it from the email

### User Impact
When viewing a user's access details, administrators will now see:
- **Originally:** Only last name and first name were displayed
- **Now:** Email address with IDIR username in parentheses: `user@example.com (TESTIDIR)`

This makes it easier to identify users, especially when multiple users might have similar names or when working with government IDIR accounts.

### Notes
- The IDIR username is only displayed if it exists in the user's profile
- If a user doesn't have an IDIR username, the display remains unchanged (just shows the email)
- The change is backward compatible and doesn't affect existing functionality
