### PR TITLE
CENTR-97:Banner on Request Access page for DST/EPIC.auth admins

### DIFF
--- a/centre-web/src/routes/_authenticated/request-access/index.tsx
+++ b/centre-web/src/routes/_authenticated/request-access/index.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/_authenticated/request-access/")({
 function RequestAccess() {
   const { data: applications = [], isPending } =
     useGetRequestCatalogApplications();
-  const { isDstAdmin } = useCurrentUser();
+  const { isAdmin } = useCurrentUser();
 
   if (isPending) {
     return <PageLoader />;
@@ -33,12 +33,12 @@ function RequestAccess() {
             responsibilities.
           </Typography>
         </Grid>
-        {!isDstAdmin && (<Grid item xs={12} mt="32px">
+        {!isAdmin && (<Grid item xs={12} mt="32px">
           <Typography variant="body1" fontWeight={"bold"}>
             You will receive an email when your request has been processed.
           </Typography>
         </Grid>)}
-        {isDstAdmin && (
+        {isAdmin && (
           <Grid item xs={12} mt="32px">
             <Box
               sx={{


### PR DESCRIPTION
Summary
This PR updates the Request Access page to conditionally display messages based on user admin status. The changes ensure that:

Regular users (non-admins) see the email notification message
DST admins or users who are admins in any app see the EPIC.auth Superuser message
Changes:

Updated email notification message to only show for non-admin users
Updated EPIC.auth Superuser message to show for DST admins or any app admins