### PR TITLE
CENTR-105:Hide Last Accessed field for untracked or null apps

### DIFF
--- a/centre-web/src/components/LaunchAppTile/AccessLogSection.tsx
+++ b/centre-web/src/components/LaunchAppTile/AccessLogSection.tsx
@@ -36,12 +36,14 @@ export const AccessLogSection = ({ user }: AccessLogSectionProps) => {
       >
         <Typography variant="body2">{user.access_level ?? ""}</Typography>
       </LabeledItem>
-      <LabeledItem 
-        label="Last Accessed"
-        labelProps={{ sx: { minWidth: "100px" } }}
-      >
-        <Typography variant="body2">{formatLastAccessed(user.last_accessed)}</Typography>
-      </LabeledItem>
+      {user.last_accessed && (
+        <LabeledItem 
+          label="Last Accessed"
+          labelProps={{ sx: { minWidth: "100px" } }}
+        >
+          <Typography variant="body2">{formatLastAccessed(user.last_accessed)}</Typography>
+        </LabeledItem>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
Summary:
Hide the Last Accessed field for apps where last-access tracking is disabled or the value is null.