### PR TITLE
CENTR-127:Display Requested Date/Time in User Table

### DIFF
--- a/centre-web/src/components/AuthManagement/NewRequests/RequestsTable/TableBody.tsx
+++ b/centre-web/src/components/AuthManagement/NewRequests/RequestsTable/TableBody.tsx
@@ -7,6 +7,17 @@ import { CentreLink } from "@/components/Shared/CentreLink";
 import { getAppChipTitle } from "../../utils";
 import { AppChip } from "@/components/Shared/AppChip";
 import { useNavigate } from "@tanstack/react-router";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+
+const formatRequestedDate = (isoDateString: string | null | undefined): string => {
+  if (!isoDateString) return "";
+  const date = dayjs.utc(isoDateString);
+  if (!date.isValid()) return "";
+  return date.local().format("YYYY-MM-DD");
+};
 
 type GroupedRequest = Partial<CentreUser> & {
   requests: AccessRequest[];
@@ -36,11 +47,22 @@ export const RequestsTableBody: React.FC<TableBodyProps> = ({
     });
   };
 
+  const getEarliestRequestedDate = (requests: AccessRequest[]) => {
+    const dates = requests
+      .map((r) => r.created_date)
+      .filter((d): d is string => d != null);
+    if (dates.length === 0) return "";
+    const earliest = [...dates].sort((a, b) =>
+      new Date(a).getTime() - new Date(b).getTime(),
+    )[0];
+    return formatRequestedDate(earliest);
+  };
+
   if (isLoading) {
     return (
       <TableBody>
         <TableRow>
-          <CentreTableCell colSpan={3}>
+          <CentreTableCell colSpan={4}>
             <Stack direction="column" alignItems="center">
               Loading...
               <LinearProgress sx={{ width: "100%" }} />
@@ -55,7 +77,7 @@ export const RequestsTableBody: React.FC<TableBodyProps> = ({
     return (
       <TableBody>
         <TableRow>
-          <CentreTableCell colSpan={3} align="center">
+          <CentreTableCell colSpan={4} align="center">
             Error loading requests
           </CentreTableCell>
         </TableRow>
@@ -67,7 +89,7 @@ export const RequestsTableBody: React.FC<TableBodyProps> = ({
     return (
       <TableBody>
         <TableRow>
-          <CentreTableCell colSpan={3} align="center">
+          <CentreTableCell colSpan={4} align="center">
             {searchText
               ? `No requests found matching "${searchText}"`
               : "No requests found"}
@@ -82,6 +104,9 @@ export const RequestsTableBody: React.FC<TableBodyProps> = ({
       {userRequests.map((user) => (
         <TableRow key={user.user_auth_guid}>
           <CentreTableCell>{`${user.last_name ?? ""}, ${user.first_name ?? ""}`}</CentreTableCell>
+          <CentreTableCell>
+            {getEarliestRequestedDate(user.requests)}
+          </CentreTableCell>
           <CentreTableCell sx={{ height: "35px" }}>
             <Stack direction="row" spacing={1} flexWrap="wrap">
               {user.requests.map((request: any) => (
@@ -105,7 +130,7 @@ export const RequestsTableBody: React.FC<TableBodyProps> = ({
           (_, idx) => (
             <TableRow key={`empty-row-${userRequests.length}-${idx}`}>
               <CentreTableCell
-                colSpan={3}
+                colSpan={4}
                 style={{
                   height: "35px",
                   border: "1px solid transparent",

--- a/centre-web/src/components/AuthManagement/NewRequests/RequestsTable/TableHead.tsx
+++ b/centre-web/src/components/AuthManagement/NewRequests/RequestsTable/TableHead.tsx
@@ -16,7 +16,10 @@ export default function RequestsTableHead() {
         <CentreTableHeadCell sx={{ width: "20%" }}>
           User Name
         </CentreTableHeadCell>
-        <CentreTableHeadCell sx={{ width: "65%" }}>
+        <CentreTableHeadCell sx={{ width: "15%" }}>
+          Requested Date
+        </CentreTableHeadCell>
+        <CentreTableHeadCell sx={{ width: "50%" }}>
           Application
         </CentreTableHeadCell>
         <CentreTableHeadCell sx={{ width: "15%" }}>Action</CentreTableHeadCell>

--- a/centre-web/src/components/AuthManagement/UserAccess/NewAccessRequests/NewRequestsTable.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/NewAccessRequests/NewRequestsTable.tsx
@@ -7,6 +7,17 @@ import { CentreLink } from "@/components/Shared/CentreLink";
 import { AccessRequest } from "@/models/AccessRequest";
 import { CentreUser } from "@/models/CentreUser";
 import { Table, TableBody, TableContainer, TableRow } from "@mui/material";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+
+const formatRequestedDate = (isoDateString: string | null | undefined): string => {
+  if (!isoDateString) return "";
+  const date = dayjs.utc(isoDateString);
+  if (!date.isValid()) return "";
+  return date.local().format("YYYY-MM-DD");
+};
 import { getAppChipTitle } from "../../utils";
 import { useModal } from "@/components/Shared/Modals/modalStore";
 import { EditAccessModal } from "../../EditAccess";
@@ -89,6 +100,18 @@ export const NewRequestsTable = ({
             <CentreTableHeadCell
               sx={{
                 width: {
+                  xs: "18%",
+                  sm: "18%",
+                  md: "15%",
+                  lg: "15%",
+                },
+              }}
+            >
+              Requested Date
+            </CentreTableHeadCell>
+            <CentreTableHeadCell
+              sx={{
+                width: {
                   xs: "28%",
                   sm: "30%",
                   md: "20%",
@@ -129,6 +152,9 @@ export const NewRequestsTable = ({
                 <CentreTableCell>
                   {getAppChipTitle(request.app.name)}
                 </CentreTableCell>
+                <CentreTableCell>
+                  {formatRequestedDate(request.created_date)}
+                </CentreTableCell>
                 <CentreTableCell>--</CentreTableCell>
                 <CentreTableCell>
                   <CentreLink onClick={() => handleEditAccess(request)}>
@@ -149,7 +175,7 @@ export const NewRequestsTable = ({
             ))
           ) : (
             <TableRow>
-              <CentreTableCell align="center" colSpan={4}>
+              <CentreTableCell align="center" colSpan={5}>
                 No pending access requests.
               </CentreTableCell>
             </TableRow>


### PR DESCRIPTION
Summary
Adds a Requested Date column to both tables in the New Access Requests flow, allowing administrators to view when access was requested. Dates use the same format as “Last Accessed”

New Access Requests: (user detail): New “Requested Date” column showing each request’s created_date.
New Access Requests: (main table in New Access Requests tab): New “Requested Date” column showing the earliest request date per user.