### PR TITLE
CENTR-128 – Add Access Level & Application filters in Centre User table (DST only)

### DIFF
--- a/centre-web/src/components/AuthManagement/AllUsers/index.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/index.tsx
@@ -19,7 +19,40 @@ import {
   APP_ACCESS_LEVELS,
 } from "@/models/EpicApp";
 import { useState, useMemo } from "react";
+import { BCDesignTokens } from "epic.theme";
 import { getAppChipTitle } from "../utils";
+
+const DROPDOWN_MIN_WIDTH = 250;
+const borderColor = BCDesignTokens.surfaceColorBorderDefault;
+/** Border styles for Application and Access level dropdowns (match search field). */
+const dropdownInputSx = {
+  "& .MuiOutlinedInput-notchedOutline": {
+    borderWidth: "1px !important",
+    borderColor: `${borderColor} !important`,
+  },
+  "&:hover .MuiOutlinedInput-notchedOutline": {
+    borderColor: `${borderColor} !important`,
+  },
+  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    borderWidth: "1px !important",
+    borderColor: `${borderColor} !important`,
+  },
+};
+/** Disabled state for Access level dropdown (light gray background only). Applied on FormControl so it targets the input inside. */
+const disabledAccessLevelFormControlSx = {
+  "& .MuiInputBase-root.Mui-disabled": {
+    backgroundColor: "#f5f5f5 !important",
+  },
+  "& .Mui-disabled.MuiInputBase-root": {
+    backgroundColor: "#f5f5f5 !important",
+  },
+  "& .MuiOutlinedInput-root.Mui-disabled": {
+    backgroundColor: "#f5f5f5 !important",
+  },
+  "& .MuiInputBase-root.Mui-disabled .MuiOutlinedInput-notchedOutline": {
+    borderColor: "#e0e0e0",
+  },
+};
 
 const ALL_VALUE = "";
 
@@ -145,7 +178,7 @@ export const AllUsers = () => {
           </Button>
           {isDstAdmin && (
             <>
-              <FormControl size="small" sx={{ minWidth: 180 }}>
+              <FormControl size="small" sx={{ minWidth: DROPDOWN_MIN_WIDTH }}>
                 <InputLabel id="all-users-app-filter-label">
                   Application
                 </InputLabel>
@@ -154,6 +187,7 @@ export const AllUsers = () => {
                   value={selectedAppName}
                   label="Application"
                   onChange={(e) => handleAppChange(e.target.value)}
+                  sx={dropdownInputSx}
                 >
                   <MenuItem value={ALL_VALUE}>All</MenuItem>
                   {ALL_USERS_FILTER_APP_NAMES.map((name) => (
@@ -166,17 +200,8 @@ export const AllUsers = () => {
               <FormControl
                 size="small"
                 sx={{
-                  minWidth: 180,
-                  "& .MuiInputBase-root.Mui-disabled": {
-                    backgroundColor: "#f5f5f5",
-                  },
-                  "& .MuiInputBase-input.Mui-disabled": {
-                    WebkitTextFillColor: "#9e9e9e",
-                    color: "#9e9e9e",
-                  },
-                  "& .MuiInputLabel-root.Mui-disabled": {
-                    color: "#9e9e9e",
-                  },
+                  minWidth: DROPDOWN_MIN_WIDTH,
+                  ...disabledAccessLevelFormControlSx,
                 }}
                 disabled={!selectedAppName}
               >
@@ -190,6 +215,12 @@ export const AllUsers = () => {
                   onChange={(e) =>
                     setSelectedAccessLevelGroupPath(e.target.value)
                   }
+                  sx={{
+                    ...dropdownInputSx,
+                    "&.Mui-disabled": {
+                      backgroundColor: "#f5f5f5 !important",
+                    },
+                  }}
                 >
                   <MenuItem value={ALL_VALUE}>All</MenuItem>
                   {accessLevels.map((level) => (

--- a/centre-web/src/components/AuthManagement/AllUsers/index.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/index.tsx
@@ -1,27 +1,75 @@
-import { Button, Grid, IconButton, Stack, TextField } from "@mui/material";
+import {
+  Button,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import CancelIcon from "@mui/icons-material/Cancel";
 import { UsersTable } from "./UsersTable";
+import { useCurrentUser } from "@/contexts/UserContext";
 import { useGetUsers } from "@/hooks/api/useUsers";
-import { useState } from "react";
+import {
+  ALL_USERS_FILTER_APP_NAMES,
+  APP_ACCESS_LEVELS,
+} from "@/models/EpicApp";
+import { useState, useMemo } from "react";
+import { getAppChipTitle } from "../utils";
+
+const ALL_VALUE = "";
+
+/** Normalize group path for comparison (Keycloak may return paths with leading/trailing slashes or different casing). */
+function normalizeGroupPath(path: string | null | undefined): string {
+  if (path == null || path === "") return "";
+  return path.replaceAll(/(^(?:\/)+)|((?:\/)+$)/g, "").toUpperCase();
+}
 
 export const AllUsers = () => {
+  const { isDstAdmin } = useCurrentUser();
   const [searchText, setSearchText] = useState("");
+  const [selectedAppName, setSelectedAppName] = useState<string>(ALL_VALUE);
+  const [selectedAccessLevelGroupPath, setSelectedAccessLevelGroupPath] =
+    useState<string>(ALL_VALUE);
 
-  const [queryParams, setQueryParams] = useState<{
-    search?: string;
-    include_groups?: boolean;
-  }>({});
+  const [queryParams, setQueryParams] = useState<{ search?: string }>({});
   const {
     data: users = [],
     isLoading,
     isError,
-  } = useGetUsers({
-    ...queryParams,
-    include_groups: false,
-  });
+  } = useGetUsers(queryParams);
 
-  const filteredUsers = users.filter((user) => user.username.includes("@idir"));
+  const accessLevels = selectedAppName
+    ? APP_ACCESS_LEVELS[selectedAppName] ?? []
+    : [];
+
+  const filteredUsers = useMemo(() => {
+    let result = users.filter((user) => user.username.includes("@idir"));
+
+    if (selectedAppName) {
+      const normalizedSelectedPath = selectedAccessLevelGroupPath
+        ? normalizeGroupPath(selectedAccessLevelGroupPath)
+        : null;
+      result = result.filter((user) =>
+        user.apps?.some((app) => {
+          if (app.name !== selectedAppName) return false;
+          const path = normalizeGroupPath(app.group_path);
+          // User must have an actual access level (non-empty path) for this app
+          if (!path) return false;
+          if (normalizedSelectedPath) {
+            return path === normalizedSelectedPath;
+          }
+          return true; // Access level "All": show users with any access to this app
+        }),
+      );
+    }
+
+    return result;
+  }, [users, selectedAppName, selectedAccessLevelGroupPath]);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchText(event.target.value);
@@ -29,11 +77,15 @@ export const AllUsers = () => {
 
   const handleSearchTrigger = () => {
     setQueryParams({ search: searchText });
+    setSelectedAppName(ALL_VALUE);
+    setSelectedAccessLevelGroupPath(ALL_VALUE);
   };
 
   const handleClearSearch = () => {
     setSearchText("");
     setQueryParams({ search: "" });
+    setSelectedAppName(ALL_VALUE);
+    setSelectedAccessLevelGroupPath(ALL_VALUE);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -42,10 +94,15 @@ export const AllUsers = () => {
     }
   };
 
+  const handleAppChange = (value: string) => {
+    setSelectedAppName(value);
+    setSelectedAccessLevelGroupPath(ALL_VALUE);
+  };
+
   return (
     <Grid container spacing={2} mt={"1em"}>
       <Grid item xs={12}>
-        <Stack direction="row" spacing={1} alignItems="center">
+        <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
           <TextField
             variant="outlined"
             placeholder="Enter the first three letters of the user’s First or Last name"
@@ -86,6 +143,64 @@ export const AllUsers = () => {
           >
             <SearchIcon sx={{ height: "30px", width: "30px" }} />
           </Button>
+          {isDstAdmin && (
+            <>
+              <FormControl size="small" sx={{ minWidth: 180 }}>
+                <InputLabel id="all-users-app-filter-label">
+                  Application
+                </InputLabel>
+                <Select
+                  labelId="all-users-app-filter-label"
+                  value={selectedAppName}
+                  label="Application"
+                  onChange={(e) => handleAppChange(e.target.value)}
+                >
+                  <MenuItem value={ALL_VALUE}>All</MenuItem>
+                  {ALL_USERS_FILTER_APP_NAMES.map((name) => (
+                    <MenuItem key={name} value={name}>
+                      {getAppChipTitle(name)}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl
+                size="small"
+                sx={{
+                  minWidth: 180,
+                  "& .MuiInputBase-root.Mui-disabled": {
+                    backgroundColor: "#f5f5f5",
+                  },
+                  "& .MuiInputBase-input.Mui-disabled": {
+                    WebkitTextFillColor: "#9e9e9e",
+                    color: "#9e9e9e",
+                  },
+                  "& .MuiInputLabel-root.Mui-disabled": {
+                    color: "#9e9e9e",
+                  },
+                }}
+                disabled={!selectedAppName}
+              >
+                <InputLabel id="all-users-access-level-filter-label">
+                  Access level
+                </InputLabel>
+                <Select
+                  labelId="all-users-access-level-filter-label"
+                  value={selectedAccessLevelGroupPath}
+                  label="Access level"
+                  onChange={(e) =>
+                    setSelectedAccessLevelGroupPath(e.target.value)
+                  }
+                >
+                  <MenuItem value={ALL_VALUE}>All</MenuItem>
+                  {accessLevels.map((level) => (
+                    <MenuItem key={level.group_path} value={level.group_path}>
+                      {level.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </>
+          )}
         </Stack>
       </Grid>
       <Grid item xs={12}>

--- a/centre-web/src/components/AuthManagement/AllUsers/index.tsx
+++ b/centre-web/src/components/AuthManagement/AllUsers/index.tsx
@@ -13,46 +13,19 @@ import SearchIcon from "@mui/icons-material/Search";
 import CancelIcon from "@mui/icons-material/Cancel";
 import { UsersTable } from "./UsersTable";
 import { useCurrentUser } from "@/contexts/UserContext";
+import {
+  disabledAccessLevelFormControlSx,
+  dropdownInputSx,
+} from "@/components/Shared/filterDropdownStyles";
 import { useGetUsers } from "@/hooks/api/useUsers";
 import {
   ALL_USERS_FILTER_APP_NAMES,
   APP_ACCESS_LEVELS,
 } from "@/models/EpicApp";
 import { useState, useMemo } from "react";
-import { BCDesignTokens } from "epic.theme";
 import { getAppChipTitle } from "../utils";
 
 const DROPDOWN_MIN_WIDTH = 250;
-const borderColor = BCDesignTokens.surfaceColorBorderDefault;
-/** Border styles for Application and Access level dropdowns (match search field). */
-const dropdownInputSx = {
-  "& .MuiOutlinedInput-notchedOutline": {
-    borderWidth: "1px !important",
-    borderColor: `${borderColor} !important`,
-  },
-  "&:hover .MuiOutlinedInput-notchedOutline": {
-    borderColor: `${borderColor} !important`,
-  },
-  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-    borderWidth: "1px !important",
-    borderColor: `${borderColor} !important`,
-  },
-};
-/** Disabled state for Access level dropdown (light gray background only). Applied on FormControl so it targets the input inside. */
-const disabledAccessLevelFormControlSx = {
-  "& .MuiInputBase-root.Mui-disabled": {
-    backgroundColor: "#f5f5f5 !important",
-  },
-  "& .Mui-disabled.MuiInputBase-root": {
-    backgroundColor: "#f5f5f5 !important",
-  },
-  "& .MuiOutlinedInput-root.Mui-disabled": {
-    backgroundColor: "#f5f5f5 !important",
-  },
-  "& .MuiInputBase-root.Mui-disabled .MuiOutlinedInput-notchedOutline": {
-    borderColor: "#e0e0e0",
-  },
-};
 
 const ALL_VALUE = "";
 

--- a/centre-web/src/components/AuthManagement/utils.ts
+++ b/centre-web/src/components/AuthManagement/utils.ts
@@ -3,11 +3,13 @@ import { EpicAppName } from "@/models/EpicApp";
 const EpicAppNameToChipTitleMap = {
   [EpicAppName.CONDITION_REPOSITORY]: "Cond. Repo.",
   [EpicAppName.EPIC_COMPLIANCE]: "EPIC.compliance",
+  [EpicAppName.DOCUMENT_SEARCH]: "Document Search",
   [EpicAppName.EPIC_TRACK]: "EPIC.track",
+  [EpicAppName.EPIC_PUBLIC]: "EPIC.public",
   [EpicAppName.EPIC_SUBMIT]: "EPIC.submit",
   [EpicAppName.EPIC_ENGAGE]: "EPIC.engage",
-  [EpicAppName.EPIC_PUBLIC]: "EPIC.public",
-   [EpicAppName.EPIC_CENTRE]: "EPIC.auth",
+  [EpicAppName.EPIC_CENTRE]: "EPIC.auth",
+  [EpicAppName.INTRANET]: "Intranet",
 };
 
 export const getAppChipTitle = (appName: string): string => {

--- a/centre-web/src/components/Shared/filterDropdownStyles.ts
+++ b/centre-web/src/components/Shared/filterDropdownStyles.ts
@@ -1,0 +1,34 @@
+import { BCDesignTokens } from "epic.theme";
+
+const borderColor = BCDesignTokens.surfaceColorBorderDefault;
+
+/** Border styles for Application and Access level dropdowns (match search field). */
+export const dropdownInputSx = {
+  "& .MuiOutlinedInput-notchedOutline": {
+    borderWidth: "1px !important",
+    borderColor: `${borderColor} !important`,
+  },
+  "&:hover .MuiOutlinedInput-notchedOutline": {
+    borderColor: `${borderColor} !important`,
+  },
+  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    borderWidth: "1px !important",
+    borderColor: `${borderColor} !important`,
+  },
+};
+
+/** Disabled state for Access level dropdown (light gray background). Applied on FormControl so it targets the input inside. */
+export const disabledAccessLevelFormControlSx = {
+  "& .MuiInputBase-root.Mui-disabled": {
+    backgroundColor: "#f5f5f5 !important",
+  },
+  "& .Mui-disabled.MuiInputBase-root": {
+    backgroundColor: "#f5f5f5 !important",
+  },
+  "& .MuiOutlinedInput-root.Mui-disabled": {
+    backgroundColor: "#f5f5f5 !important",
+  },
+  "& .MuiInputBase-root.Mui-disabled .MuiOutlinedInput-notchedOutline": {
+    borderColor: "#e0e0e0",
+  },
+};

--- a/centre-web/src/hooks/api/useUsers.ts
+++ b/centre-web/src/hooks/api/useUsers.ts
@@ -21,7 +21,7 @@ const getUsers = (params: GetUsersParams) => {
 
 export const useGetUsers = (params: GetUsersParams = {}) => {
   return useQuery({
-    queryKey: [QUERY_KEY.USERS, params.search],
+    queryKey: [QUERY_KEY.USERS, params.search, params.include_groups],
     queryFn: () => getUsers(params),
   });
 };

--- a/centre-web/src/models/EpicApp.ts
+++ b/centre-web/src/models/EpicApp.ts
@@ -75,8 +75,8 @@ export const APP_ACCESS_LEVELS: Readonly<Record<string, AppAccessLevelOption[]>>
     { group_path: "ENGAGE/VIEWER", name: "Viewer" },
   ],
   [EpicAppName.EPIC_PUBLIC]: [
-    { group_path: "PUBLIC/ADMIN", name: "Admin" },
-    { group_path: "PUBLIC/VIEWER", name: "Viewer" },
+    { group_path: "PUBLIC/INSTANCE_ADMIN", name: "Instance Admin" },
+    { group_path: "PUBLIC/STAFF", name: "Staff" },
   ],
   [EpicAppName.EPIC_SUBMIT]: [
     { group_path: "SUBMIT/EAO_MANAGER", name: "Manager" },

--- a/centre-web/src/models/EpicApp.ts
+++ b/centre-web/src/models/EpicApp.ts
@@ -35,6 +35,60 @@ export enum EpicAppName {
   INTRANET = "intranet",
 }
 
+/** All EPIC app names for use in filters (e.g. All Users application dropdown). */
+export const ALL_EPIC_APP_NAMES: string[] = Object.values(EpicAppName);
+
+/** EPIC app names shown in the Centre All Users application filter dropdown. */
+export const ALL_USERS_FILTER_APP_NAMES: string[] = [
+  EpicAppName.CONDITION_REPOSITORY,
+  EpicAppName.EPIC_CENTRE,
+  EpicAppName.EPIC_COMPLIANCE,
+  EpicAppName.EPIC_ENGAGE,
+  EpicAppName.EPIC_PUBLIC,
+  EpicAppName.EPIC_SUBMIT,
+  EpicAppName.EPIC_TRACK,
+];
+
+/** Access level option for filter dropdown (group_path must match user.apps[].group_path from API). */
+export type AppAccessLevelOption = { group_path: string; name: string };
+
+/**
+ * Static map of app name → access levels for the All Users filter dropdown.
+ * Eliminates API delay; group_path values must match Keycloak/API (paths are normalized when comparing).
+ * Add or update entries here if new roles are added in Keycloak.
+ */
+export const APP_ACCESS_LEVELS: Readonly<Record<string, AppAccessLevelOption[]>> = {
+  [EpicAppName.CONDITION_REPOSITORY]: [
+    { group_path: "CONDITION-REPO/ADMIN", name: "Admin" },
+  ],
+  [EpicAppName.EPIC_CENTRE]: [
+    { group_path: "CENTRE/SUPER_USER", name: "Super User" },
+    { group_path: "CENTRE/ADMIN", name: "Admin" },
+  ],
+  [EpicAppName.EPIC_COMPLIANCE]: [
+    { group_path: "COMPLIANCE/SUPERUSER", name: "Super User" },
+    { group_path: "COMPLIANCE/VIEWER", name: "Viewer" },
+  ],
+  [EpicAppName.EPIC_ENGAGE]: [
+    { group_path: "ENGAGE/INSTANCE_ADMIN", name: "Super User" },
+    { group_path: "ENGAGE/EAO_IT_ADMIN", name: "Admin" },
+    { group_path: "ENGAGE/VIEWER", name: "Viewer" },
+  ],
+  [EpicAppName.EPIC_PUBLIC]: [
+    { group_path: "PUBLIC/ADMIN", name: "Admin" },
+    { group_path: "PUBLIC/VIEWER", name: "Viewer" },
+  ],
+  [EpicAppName.EPIC_SUBMIT]: [
+    { group_path: "SUBMIT/EAO_MANAGER", name: "Manager" },
+    { group_path: "SUBMIT/VIEWER", name: "Viewer" },
+  ],
+  [EpicAppName.EPIC_TRACK]: [
+    { group_path: "TRACK/SUPER_USER", name: "Super User" },
+    { group_path: "TRACK/INSTANCE_ADMIN", name: "Admin" },
+    { group_path: "TRACK/VIEWER", name: "Viewer" },
+  ],
+};
+
 export enum EpicAppClientName {
   CONDITION_REPOSITORY = "epic-condition",
   EPIC_COMPLIANCE = "epic-compliance",


### PR DESCRIPTION
Summary
Adds Application and Access level dropdown filters to the Centre All Users table (EPIC.auth). Both filters are shown only to DST (EPIC.auth) admins; other admins still see the table with search only.

Changes:
Filter behaviour:
Application – Filter users by app (Cond. Repo., EPIC.auth, EPIC.compliance, EPIC.engage, EPIC.public, EPIC.submit, EPIC.track). “All” shows every user.
Access level – Depends on selected application; filter by role (e.g. Admin, Super User, Manager). “All” shows users with any access to that app. Users with no access for that app (e.g. group_path null) are excluded when an app is selected.