### PR TITLE
CENTR-129:Add last accessed time for users logged in to centre

### DIFF
--- a/centre-api/migrations/versions/c3d4e5f6a7b8_add_epic_centre_application.py
+++ b/centre-api/migrations/versions/c3d4e5f6a7b8_add_epic_centre_application.py
@@ -1,0 +1,54 @@
+"""Add epic_centre to applications table for analytics
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2025-02-20
+
+"""
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "c3d4e5f6a7b8"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    applications_table = sa.table(
+        "applications",
+        sa.column("title", sa.String),
+        sa.column("name", sa.String),
+        sa.column("description", sa.Text),
+        sa.column("launch_url", sa.Text),
+        sa.column("is_active", sa.Boolean),
+        sa.column("created_date", sa.DateTime),
+        sa.column("updated_date", sa.DateTime),
+        sa.column("created_by", sa.String),
+        sa.column("updated_by", sa.String),
+    )
+
+    op.bulk_insert(
+        applications_table,
+        [
+            {
+                "title": "EPIC.centre",
+                "name": "epic_centre",
+                "description": "Central hub for EAO applications and user management",
+                "launch_url": "",
+                "is_active": False,
+                "created_date": datetime.now(timezone.utc),
+                "updated_date": None,
+                "created_by": None,
+                "updated_by": None,
+            }
+        ],
+    )
+
+
+def downgrade():
+    op.execute("DELETE FROM applications WHERE name = 'epic_centre'")

--- a/centre-api/src/centre_api/services/applications_service.py
+++ b/centre-api/src/centre_api/services/applications_service.py
@@ -89,7 +89,7 @@ class ApplicationsService:
             return []
 
         apps = ApplicationModel.get_all()
-        apps = [(app, user_app) for app, user_app in apps if app.name in accessed_apps]
+        apps = [(app, user_app) for app, user_app in apps if app.name in accessed_apps and app.is_active]
 
         user_access_levels = cls._get_current_user_access_levels()
         user_auth_username = TokenInfo.get_username()
@@ -126,7 +126,7 @@ class ApplicationsService:
         apps = ApplicationModel.get_all()
         exception_apps = {EpicAppName.CONDITION_REPOSITORY.value, EpicAppName.EPIC_COMPLIANCE.value,
                           EpicAppName.DOCUMENT_SEARCH.value, EpicAppName.INTRANET.value}
-        filtered_apps = [(app, user_app) for app, user_app in apps if app.name not in exception_apps]
+        filtered_apps = [(app, user_app) for app, user_app in apps if app.name not in exception_apps and app.is_active]
 
         access_levels = cls._get_current_user_access_levels()
         accessed_apps = set(access_levels.keys())

--- a/centre-web/src/hooks/api/useEaoAnalytics.ts
+++ b/centre-web/src/hooks/api/useEaoAnalytics.ts
@@ -1,0 +1,23 @@
+import { centreRequest } from "@/utils/axiosUtils";
+import { useMutation } from "@tanstack/react-query";
+
+export const EPIC_CENTRE_APP_NAME = "epic_centre";
+
+type RecordLoginParams = {
+  user_auth_guid: string;
+  app_name: string;
+};
+
+const recordLogin = ({ user_auth_guid, app_name }: RecordLoginParams) => {
+  return centreRequest({
+    url: "eao-analytics",
+    method: "POST",
+    data: { user_auth_guid, app_name },
+  });
+};
+
+export const useRecordLogin = () => {
+  return useMutation({
+    mutationFn: recordLogin,
+  });
+};

--- a/centre-web/src/routes/_authenticated.tsx
+++ b/centre-web/src/routes/_authenticated.tsx
@@ -1,10 +1,14 @@
 import { PageLoader } from "@/components/PageLoader";
 import SideNavBar from "@/components/SideNav/SideNavBar";
 import { useCurrentUser } from "@/contexts/UserContext";
+import {
+  useRecordLogin,
+  EPIC_CENTRE_APP_NAME,
+} from "@/hooks/api/useEaoAnalytics";
 import { OidcConfig } from "@/utils/config";
 import { Box } from "@mui/material";
 import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAuth } from "react-oidc-context";
 
 export const Route = createFileRoute("/_authenticated")({
@@ -13,7 +17,9 @@ export const Route = createFileRoute("/_authenticated")({
 
 function AuthenticatedRoute() {
   const { isAuthenticated, signinRedirect, isLoading } = useAuth();
-  const { isLoading: userLoading } = useCurrentUser();
+  const { user, isLoading: userLoading } = useCurrentUser();
+  const { mutate: recordLogin } = useRecordLogin();
+  const hasRecordedLogin = useRef(false);
 
   useEffect(() => {
     if (!isAuthenticated && !isLoading) {
@@ -25,6 +31,17 @@ function AuthenticatedRoute() {
       });
     }
   }, [isAuthenticated, isLoading, signinRedirect]);
+
+  // Record login to centre API (eao-analytics) once per session
+  useEffect(() => {
+    if (user?.id && !hasRecordedLogin.current) {
+      hasRecordedLogin.current = true;
+      recordLogin(
+        { user_auth_guid: user.id, app_name: EPIC_CENTRE_APP_NAME },
+        { onError: () => {} },
+      );
+    }
+  }, [user?.id, recordLogin]);
 
   if (isLoading || userLoading) {
     return <PageLoader />;

--- a/centre-web/src/utils/config.ts
+++ b/centre-web/src/utils/config.ts
@@ -42,6 +42,8 @@ const INTRANET_HUB_URL =
 
 export const AppConfig = {
   apiUrl: `${API_URL}/api`,
+  /** Base URL of the centre API (no /api suffix). Used by @epic/centre-analytics. */
+  apiBaseUrl: API_URL,
   environment: APP_ENVIRONMENT,
   version: APP_VERSION,
   appTitle: APP_TITLE,


### PR DESCRIPTION
Summary
Adds EPIC.centre to the applications table and records user logins via the existing EAO analytics (eao-analytics) API, so centre logins are tracked like other EPIC apps (e.g. EPIC.submit). EPIC.centre is kept off the launchpad and request access UI by inserting it with is_active: false and filtering the API by is_active.

Changes:
centre-api
Migration c3d4e5f6a7b8_add_epic_centre_application.py: Inserts epic_centre into the applications table with is_active: False so it can be used for analytics but is hidden from launchpad and request access.
ApplicationsService: In get_all() and get_request_catalog(), only applications with app.is_active are returned, so inactive apps (including EPIC.centre) do not appear on the launchpad or request access page.

centre-web
useEaoAnalytics hook: Calls the centre API POST /api/eao-analytics with user_auth_guid and app_name: "epic_centre" (uses existing centreRequest and auth token).
Authenticated route: When the user is authenticated and user data is loaded, records a login once per session via the hook (ref used to avoid duplicate calls). Failures are ignored so they do not affect the UI.