### PR TITLE
CENTR-130:Show disabled user permissions greyed out

### DIFF
--- a/centre-web/src/components/AuthManagement/UserAccess/AppUserManagementButton.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/AppUserManagementButton.tsx
@@ -1,15 +1,17 @@
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import { Box } from "@mui/material";
 import { CentreLink } from "@/components/Shared/CentreLink";
 
 type AppUserManagementButtonProps = {
   appUserManagementUrl?: string;
   supportsGranularRoleManagement: boolean;
-  tabIndex?: number;
+  disabled?: boolean;
 };
 
 export const AppUserManagementButton = ({
   appUserManagementUrl,
   supportsGranularRoleManagement,
+  disabled = false,
 }: AppUserManagementButtonProps) => {
   // Don't render if the app doesn't support granular role management or if no URL is provided
   if (!supportsGranularRoleManagement || !appUserManagementUrl) {
@@ -17,10 +19,29 @@ export const AppUserManagementButton = ({
   }
 
   const handleClick = () => {
-    if (appUserManagementUrl) {
+    if (appUserManagementUrl && !disabled) {
       window.open(appUserManagementUrl, "_blank", "noopener,noreferrer");
     }
   };
+
+  if (disabled) {
+    return (
+      <Box
+        component="span"
+        sx={{
+          color: "#898785",
+          cursor: "default",
+          display: "inline-flex",
+          alignItems: "center",
+        }}
+      >
+        App User Management
+        <OpenInNewIcon
+          sx={{ fontSize: "1rem", verticalAlign: "middle", marginLeft: "4px" }}
+        />
+      </Box>
+    );
+  }
 
   return (
     <CentreLink onClick={handleClick}>

--- a/centre-web/src/components/AuthManagement/UserAccess/CurrentAccessLevel/CurrentAccessTable.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/CurrentAccessLevel/CurrentAccessTable.tsx
@@ -75,8 +75,19 @@ export const CurrentAccessTable = ({ user }: CurrentAccessTableProps) => {
     }));
   }, [user, appSupportsGranularRoleManagementMap]);
 
+  const isDisabled = user && !user.enabled;
+
   return (
-    <TableContainer>
+    <TableContainer
+      sx={
+        isDisabled
+          ? {
+              color: "#898785",
+              pointerEvents: "none",
+            }
+          : undefined
+      }
+    >
       <Table>
         <CentreTableHead>
           <TableRow>
@@ -133,25 +144,61 @@ export const CurrentAccessTable = ({ user }: CurrentAccessTableProps) => {
             apps.map((app) => (
               <TableRow key={app.name}>
                 <CentreTableCell>{getAppChipTitle(app.name)}</CentreTableCell>
-                <CentreTableCell>{app.role ?? "--"}</CentreTableCell>
-                <CentreTableCell>
-                  <CentreLink onClick={() => handleAddEditAccess(app)}>
+                <CentreTableCell
+                  sx={
+                    isDisabled
+                      ? {
+                          color: "#898785",
+                        }
+                      : undefined
+                  }
+                >
+                  {app.role ?? "--"}
+                </CentreTableCell>
+                <CentreTableCell
+                  sx={
+                    isDisabled
+                      ? { color: "#898785" }
+                      : undefined
+                  }
+                >
+                  <CentreLink
+                    disabled={isDisabled}
+                    onClick={() => handleAddEditAccess(app)}
+                  >
                     Edit Access
                   </CentreLink>
                 </CentreTableCell>
-                <CentreTableCell sx={{ minHeight: "40px" }}>
+                <CentreTableCell
+                  sx={
+                    isDisabled
+                      ? { color: "#898785", minHeight: "40px" }
+                      : { minHeight: "40px" }
+                  }
+                >
                   <AppUserManagementButton
                     appUserManagementUrl={appUrlMap.get(app.name)}
                     supportsGranularRoleManagement={
                       app.supportsGranularRoleManagement ?? false
                     }
+                    disabled={isDisabled}
                   />
                 </CentreTableCell>
               </TableRow>
             ))
           ) : (
             <TableRow>
-              <CentreTableCell align="center" colSpan={4}>
+              <CentreTableCell
+                align="center"
+                colSpan={4}
+                sx={
+                  isDisabled
+                    ? {
+                        color: "#898785",
+                      }
+                    : undefined
+                }
+              >
                 No Existing access.
               </CentreTableCell>
             </TableRow>

--- a/centre-web/src/components/AuthManagement/UserAccess/NewAccessRequests/NewRequestsTable.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/NewAccessRequests/NewRequestsTable.tsx
@@ -69,8 +69,19 @@ export const NewRequestsTable = ({
 
     setModalOpen(modalWithFocusReturn);
   };
+
+  const isDisabled = user && !user.enabled;
+
   return (
-    <TableContainer>
+    <TableContainer
+      sx={
+        isDisabled
+          ? {
+              pointerEvents: "none",
+            }
+          : undefined
+      }
+    >
       <Table>
         <CentreTableHead>
           <TableRow>
@@ -129,13 +140,36 @@ export const NewRequestsTable = ({
                 <CentreTableCell>
                   {getAppChipTitle(request.app.name)}
                 </CentreTableCell>
-                <CentreTableCell>--</CentreTableCell>
-                <CentreTableCell>
-                  <CentreLink onClick={() => handleEditAccess(request)}>
+                <CentreTableCell
+                  sx={
+                    isDisabled
+                      ? { color: "#898785" }
+                      : undefined
+                  }
+                >
+                  --
+                </CentreTableCell>
+                <CentreTableCell
+                  sx={
+                    isDisabled
+                      ? { color: "#898785" }
+                      : undefined
+                  }
+                >
+                  <CentreLink
+                    disabled={isDisabled}
+                    onClick={() => handleEditAccess(request)}
+                  >
                     Edit Access
                   </CentreLink>
                 </CentreTableCell>
-                <CentreTableCell sx={{ minHeight: "40px" }}>
+                <CentreTableCell
+                  sx={
+                    isDisabled
+                      ? { color: "#898785", minHeight: "40px" }
+                      : { minHeight: "40px" }
+                  }
+                >
                   <AppUserManagementButton
                     appUserManagementUrl={appUrlMap.get(request.app.name)}
                     supportsGranularRoleManagement={
@@ -143,13 +177,22 @@ export const NewRequestsTable = ({
                         request.app.name,
                       ) ?? false
                     }
+                    disabled={isDisabled}
                   />
                 </CentreTableCell>
               </TableRow>
             ))
           ) : (
             <TableRow>
-              <CentreTableCell align="center" colSpan={4}>
+              <CentreTableCell
+                align="center"
+                colSpan={4}
+                sx={
+                  isDisabled
+                    ? { color: "#898785" }
+                    : undefined
+                }
+              >
                 No pending access requests.
               </CentreTableCell>
             </TableRow>

--- a/centre-web/src/components/AuthManagement/UserAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/index.tsx
@@ -1,6 +1,6 @@
 import { GreenBadge, GreyBadge } from "@/components/Shared/Badges";
 import BarTitle from "@/components/Shared/BarTitle.tsx";
-import { Alert, Box, Grid, Stack, Typography, Tooltip } from "@mui/material";
+import { Box, Grid, Stack, Typography, Tooltip } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import { NewAccessRequests } from "./NewAccessRequests";
 import { CurrentAccessLevel } from "./CurrentAccessLevel";
@@ -117,22 +117,28 @@ export const UserAccess = () => {
         >
           <Grid item xs sx={{ minWidth: 0, flex: 1}}>
             {user && !user.enabled && (
-            <Alert
-              severity="warning"
-              icon={false}
-              sx={{
-                backgroundColor: "#FCF8E3",
-                border: "1px solid #F7DF79",
-                "& .MuiAlert-message": { width: "100%" },
-              }}
-            >
-                <Typography variant="body2" component="span">
+              <Box
+                sx={{
+                  backgroundColor: "#FEF1D8",
+                  border: "1px solid #F8BB47",
+                  borderRadius: "4px",
+                  padding: "8px",
+                }}
+              >
+                <Typography
+                  variant="body1"
+                  sx={{
+                    fontSize: "16px",
+                    fontStyle: "normal",
+                    fontWeight: 400,
+                    lineHeight: "27.008px",
+                  }}
+                >
                   This user is disabled. This means they won&apos;t be able to
-                  access any EPIC applications. To re-enable this user, click the &quot;Enable&quot; button to
-                  the right.
+                  access any EPIC applications. To re-enable this user, click the
+                  &quot;Enable&quot; button to the right.
                 </Typography>
-
-              </Alert>
+              </Box>
             )}
           </Grid>
           <Grid item sx={{ flexShrink: 0 }}>

--- a/centre-web/src/components/AuthManagement/UserAccess/index.tsx
+++ b/centre-web/src/components/AuthManagement/UserAccess/index.tsx
@@ -1,6 +1,6 @@
 import { GreenBadge, GreyBadge } from "@/components/Shared/Badges";
 import BarTitle from "@/components/Shared/BarTitle.tsx";
-import { Box, Grid, Stack, Typography, Tooltip } from "@mui/material";
+import { Alert, Box, Grid, Stack, Typography, Tooltip } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import { NewAccessRequests } from "./NewAccessRequests";
 import { CurrentAccessLevel } from "./CurrentAccessLevel";
@@ -110,26 +110,54 @@ export const UserAccess = () => {
           item
           xs={12}
           container
-          alignItems={"flex-end"}
-          justifyContent={"flex-end"}
+          alignItems={"flex-start"}
+          justifyContent={"space-between"}
+          gap={2}
+          sx={{ mt: "10px", mb: "10px" }}
         >
-          {canManageUserStatus ? (
-            <LoadingButton
-              variant="outlined"
-              onClick={() => handleEnableUser(!user?.enabled)}
-              loading={isUpdating}
+          <Grid item xs sx={{ minWidth: 0, flex: 1}}>
+            {user && !user.enabled && (
+            <Alert
+              severity="warning"
+              icon={false}
+              sx={{
+                backgroundColor: "#FCF8E3",
+                border: "1px solid #F7DF79",
+                "& .MuiAlert-message": { width: "100%" },
+              }}
             >
-              {user?.enabled ? "Disable User" : "Enable User"}
-            </LoadingButton>
-          ) : (
-            <Tooltip title={disableButtonTooltip}>
-              <span>
-                <LoadingButton variant="outlined" disabled loading={isUpdating}>
-                  {user?.enabled ? "Disable User" : "Enable User"}
-                </LoadingButton>
-              </span>
-            </Tooltip>
-          )}
+                <Typography variant="body2" component="span">
+                  This user is disabled. This means they won&apos;t be able to
+                  access any EPIC applications. To re-enable this user, click the &quot;Enable&quot; button to
+                  the right.
+                </Typography>
+
+              </Alert>
+            )}
+          </Grid>
+          <Grid item sx={{ flexShrink: 0 }}>
+            {canManageUserStatus ? (
+              <LoadingButton
+                variant="outlined"
+                onClick={() => handleEnableUser(!user?.enabled)}
+                loading={isUpdating}
+              >
+                {user?.enabled ? "Disable User" : "Enable User"}
+              </LoadingButton>
+            ) : (
+              <Tooltip title={disableButtonTooltip}>
+                <span>
+                  <LoadingButton
+                    variant="outlined"
+                    disabled
+                    loading={isUpdating}
+                  >
+                    {user?.enabled ? "Disable User" : "Enable User"}
+                  </LoadingButton>
+                </span>
+              </Tooltip>
+            )}
+          </Grid>
         </Grid>
         <Grid item xs={12}>
           <NewAccessRequests user={user} />


### PR DESCRIPTION
Changes:

- Add disabled-user banner on the User Access page that matches the existing EPIC.auth Superuser banner styling, explaining that the user cannot access EPIC applications and how to re-enable them.

- Align banner and Enable/Disable button on the same row, with the banner on the left and the button on the right, and ensure the banner text uses the shared banner design/colors.

Grey out and disable actions for disabled users:

- In Current Access Level, grey the role text (#898785), grey the “Edit Access” and “App User Management” cells, disable the Edit Access link and App User Management button, and prevent interaction.

- In New Access Requests, grey the “Current Access Level” (--), grey and disable the “Edit Access” link and “App User Management” button, and grey the empty-state text when the user is disabled.