### PR TITLE
Fix platform-managed URL edits without SSL expiry

### DIFF
--- a/centre-api/src/centre_api/schemas/application_url_schema.py
+++ b/centre-api/src/centre_api/schemas/application_url_schema.py
@@ -39,7 +39,7 @@ class ApplicationUrlUpdateSchema(Schema):
         validate=validate.OneOf(['Valid', 'Expiring Soon', 'Expired', 'Error', 'Managed', 'Unknown']),
         dump_only=True
     )
-    ssl_expiry = fields.DateTime()
+    ssl_expiry = fields.DateTime(allow_none=True)
     ssl_error_message = fields.Str(dump_only=True)
     ticket_reference = fields.Str(allow_none=True)
     renewal_status = fields.Str(


### PR DESCRIPTION
## Summary
- allow application URL updates with a null ssl_expiry value
- fix edits for platform-managed URLs that do not carry an SSL expiry date
- keep the change limited to the application URL update schema

## Verification
- PYTHONPYCACHEPREFIX=/tmp python3 -m py_compile centre-api/src/centre_api/schemas/application_url_schema.py centre-api/src/centre_api/resources/application_urls.py